### PR TITLE
ExcelUI graphs now uses ID not filename as scatterplot titles

### DIFF
--- a/FlowCal/excel_ui.py
+++ b/FlowCal/excel_ui.py
@@ -527,6 +527,8 @@ def process_samples_table(samples_table,
             density_params = {}
             density_params['mode'] = 'scatter'
             density_params['log'] = True
+            ret = sample_gated.shape[0] * 100. / sample.shape[0]
+            density_params["title"] = "{} ({:.1f}% retained)".format(sample_id, ret)
             # Define histogram plot parameters
             hist_params = []
             for rc, ru in zip(report_channels, report_units):


### PR DESCRIPTION
This is a simple change to label scatterplots with the ID of the sample instead of the filename when using the ExcelUI. Fixes #170.
