### PR TITLE
Excel ui exceptions

### DIFF
--- a/FlowCal/excel_ui.py
+++ b/FlowCal/excel_ui.py
@@ -254,9 +254,9 @@ def process_beads_table(beads_table,
             except IOError:
                 raise ExcelUIException("file \"{}\" not found".format(
                     beads_row['File Path']))
-            # Check that the number of events is greater than 500
-            if beads_sample.shape[0] < 500:
-                raise ExcelUIException("number of events is lower than 500")
+            # Check that the number of events is greater than 400
+            if beads_sample.shape[0] < 400:
+                raise ExcelUIException("number of events is lower than 400")
 
             ###
             # Transform
@@ -529,9 +529,9 @@ def process_samples_table(samples_table,
             except IOError:
                 raise ExcelUIException("file \"{}\" not found".format(
                     sample_row['File Path']))
-            # Check that the number of events is greater than 500
-            if sample.shape[0] < 500:
-                raise ExcelUIException("number of events is lower than 500")
+            # Check that the number of events is greater than 400
+            if sample.shape[0] < 400:
+                raise ExcelUIException("number of events is lower than 400")
 
             ###
             # Transform

--- a/FlowCal/excel_ui.py
+++ b/FlowCal/excel_ui.py
@@ -737,6 +737,7 @@ def add_beads_stats(beads_table, beads_samples, mef_outputs=None):
     mef_outputs : list, optional
         A list with the intermediate results of the generation of the MEF
         transformation functions, as given by ``mef.get_transform_fxn()``.
+        This is used to populate the field ``<channel> Bead Model Params``.
         If specified, ``mef_outputs[i]`` should correspond to
         ``beads_table.values()[i]``.
 

--- a/FlowCal/excel_ui.py
+++ b/FlowCal/excel_ui.py
@@ -247,12 +247,16 @@ def process_beads_table(beads_table,
                 print("\nBeads ID {}...".format(beads_id))
                 print("Loading file \"{}\"...".format(beads_row['File Path']))
 
+            # Attempt to open file
             filename = os.path.join(base_dir, beads_row['File Path'])
             try:
                 beads_sample = FlowCal.io.FCSData(filename)
             except:
                 raise ExcelUIException("file \"{}\" not found".format(
                     beads_row['File Path']))
+            # Check that the number of events is greater than 500
+            if beads_sample.shape[0] < 500:
+                raise ExcelUIException("number of events is lower than 500")
 
             ###
             # Transform
@@ -508,12 +512,16 @@ def process_samples_table(samples_table,
                 print("\nSample ID {}...".format(sample_id))
                 print("Loading file \"{}\"...".format(sample_row['File Path']))
 
+            # Attempt to open file
             filename = os.path.join(base_dir, sample_row['File Path'])
             try:
                 sample = FlowCal.io.FCSData(filename)
             except:
                 raise ExcelUIException("file \"{}\" not found".format(
                     sample_row['File Path']))
+            # Check that the number of events is greater than 500
+            if sample.shape[0] < 500:
+                raise ExcelUIException("number of events is lower than 500")
 
             ###
             # Transform

--- a/FlowCal/excel_ui.py
+++ b/FlowCal/excel_ui.py
@@ -594,6 +594,7 @@ def add_beads_stats(beads_table, beads_samples):
     The following stats are added for each row, for each channel in which
     MEF values have been specified:
         - Detector voltage (gain)
+        - Amplification type
 
     Parameters
     ----------
@@ -625,9 +626,18 @@ def add_beads_stats(beads_table, beads_samples):
         for row_id, sample in zip(beads_table.index, beads_samples):
             # If MEF values are specified, calculate stats. If not, leave empty.
             if pd.notnull(beads_table[header][row_id]):
+                # Detector voltage
                 beads_table.set_value(row_id,
                                       channel + ' Detector Volt.',
                                       sample.detector_voltage(channel))
+                # Amplification type
+                if sample.amplification_type(channel)[0]:
+                    amplification_type = "Log"
+                else:
+                    amplification_type = "Linear"
+                beads_table.set_value(row_id,
+                                      channel + ' Amp. Type',
+                                      amplification_type)
 
 def add_samples_stats(samples_table, samples):
     """
@@ -639,7 +649,8 @@ def add_samples_stats(samples_table, samples):
     
     The following stats are added for each row, for each channel in which
     fluorescence units have been specified:
-        - Gain
+        - Detector voltage (gain)
+        - Amplification type
         - Mean
         - Geometric Mean
         - Media
@@ -674,6 +685,7 @@ def add_samples_stats(samples_table, samples):
     for header, channel in zip(stats_headers, stats_channels):
         # Add empty columns to table
         samples_table[channel + ' Detector Volt.'] = np.nan
+        samples_table[channel + ' Amp. Type'] = ""
         samples_table[channel + ' Mean'] = np.nan
         samples_table[channel + ' Geom. Mean'] = np.nan
         samples_table[channel + ' Median'] = np.nan
@@ -687,9 +699,21 @@ def add_samples_stats(samples_table, samples):
         for row_id, sample in zip(samples_table.index, samples):
             # If units are specified, calculate stats. If not, leave empty.
             if pd.notnull(samples_table[header][row_id]):
+                # Acquisition settings
+                # Detector voltage
                 samples_table.set_value(row_id,
                                         channel + ' Detector Volt.',
                                         sample.detector_voltage(channel))
+                # Amplification type
+                if sample.amplification_type(channel)[0]:
+                    amplification_type = "Log"
+                else:
+                    amplification_type = "Linear"
+                samples_table.set_value(row_id,
+                                        channel + ' Amp. Type',
+                                        amplification_type)
+
+                # Statistics from event list
                 samples_table.set_value(row_id,
                                         channel + ' Mean',
                                         FlowCal.stats.mean(sample, channel))

--- a/FlowCal/excel_ui.py
+++ b/FlowCal/excel_ui.py
@@ -555,12 +555,23 @@ def process_samples_table(samples_table,
                         sample = FlowCal.transform.to_rfi(sample, fl_channel)
                     elif units.lower() == 'mef':
                         units_label = "Molecules of Equivalent Fluorophore, MEF"
-                        sample = mef_transform_fxns[sample_row['Beads ID']](
-                            sample,
-                            fl_channel)
+                        # Check if function is available
+                        if mef_transform_fxns[sample_row['Beads ID']] is None:
+                            raise ExcelUIException("MEF transformation "
+                                "function not available")
+                        # Attempt to transform
+                        # Transformation function raises a ValueError if a
+                        # standard curve does not exist for a channel
+                        try:
+                            sample = mef_transform_fxns[sample_row['Beads ID']](
+                                sample,
+                                fl_channel)
+                        except ValueError:
+                            raise ExcelUIException("no standard curve for "
+                                "channel {}".format(fl_channel))
                     else:
-                        raise ValueError("units {} not recognized for sample "
-                            "{}".format(units, sample_id))
+                        raise ExcelUIException("units \"{}\" not recognized". \
+                            format(units, sample_id))
 
                     # Register that reporting in this channel must be done
                     report_channels.append(fl_channel)

--- a/FlowCal/excel_ui.py
+++ b/FlowCal/excel_ui.py
@@ -773,7 +773,9 @@ def add_beads_stats(beads_table, beads_samples, mef_outputs=None):
         beads_table[channel + ' Detector Volt.'] = np.nan
         beads_table[channel + ' Amp. Type'] = ""
         if mef_outputs:
-            beads_table[channel + ' Bead Model Params.'] = ""
+            beads_table[channel + ' Beads Model'] = ""
+            beads_table[channel + ' Beads Params. Names'] = ""
+            beads_table[channel + ' Beads Params. Values'] = ""
 
         # Iterate
         for i, row_id in enumerate(beads_table.index):
@@ -798,7 +800,7 @@ def add_beads_stats(beads_table, beads_samples, mef_outputs=None):
                                       channel + ' Amp. Type',
                                       amplification_type)
 
-                # Bead model parameters
+                # Bead model and parameters
                 # Only populate if mef_outputs has been provided
                 if mef_outputs:
                     # Try to find the current channel among the mef'd channels.
@@ -809,11 +811,26 @@ def add_beads_stats(beads_table, beads_samples, mef_outputs=None):
                     except ValueError:
                         pass
                     else:
+                        # Bead model
+                        beads_model_str = mef_outputs[i]. \
+                            fitting['beads_model_str'][mef_channel_index]
+                        beads_table.set_value(row_id,
+                                              channel + ' Beads Model',
+                                              beads_model_str)
+                        # Bead parameter names
+                        params_names = mef_outputs[i]. \
+                            fitting['beads_params_names'][mef_channel_index]
+                        params_names_str = ", ".join([str(p)
+                                                      for p in params_names])
+                        beads_table.set_value(row_id,
+                                              channel + ' Beads Params. Names',
+                                              params_names_str)
+                        # Bead parameter values
                         params = mef_outputs[i]. \
                             fitting['beads_params'][mef_channel_index]
                         params_str = ", ".join([str(p) for p in params])
                         beads_table.set_value(row_id,
-                                              channel + ' Bead Model Params.',
+                                              channel + ' Beads Params. Values',
                                               params_str)
 
 

--- a/FlowCal/excel_ui.py
+++ b/FlowCal/excel_ui.py
@@ -446,7 +446,7 @@ def process_samples_table(samples_table,
         in `samples_table` requires transformation to MEF, a key: value
         pair must exist in mef_transform_fxns, with the key being equal to
         the contents of field "Beads ID".
-    beads_table : DataFrame
+    beads_table : DataFrame, optional
         Table specifying beads samples used to generate
         `mef_transform_fxns`. This is used to check if a beads sample was
         taken at the same acquisition settings as a sample to be

--- a/FlowCal/excel_ui.py
+++ b/FlowCal/excel_ui.py
@@ -583,7 +583,7 @@ def process_samples_table(samples_table,
 
     return samples
 
-def add_beads_stats(beads_table, beads_samples):
+def add_beads_stats(beads_table, beads_samples, mef_outputs=None):
     """
     Add stats fields to beads table.
 
@@ -595,6 +595,7 @@ def add_beads_stats(beads_table, beads_samples):
     MEF values have been specified:
         - Detector voltage (gain)
         - Amplification type
+        - Bead model fitted parameters
 
     Parameters
     ----------
@@ -605,6 +606,11 @@ def add_beads_stats(beads_table, beads_samples):
     beads_samples : list
         FCSData objects from which to calculate statistics.
         ``beads_samples[i]`` should correspond to
+        ``beads_table.values()[i]``.
+    mef_outputs : list, optional
+        A list with the intermediate results of the generation of the MEF
+        transformation functions, as given by ``mef.get_transform_fxn()``.
+        If specified, ``mef_outputs[i]`` should correspond to
         ``beads_table.values()[i]``.
 
     """
@@ -623,21 +629,48 @@ def add_beads_stats(beads_table, beads_samples):
     for header, channel in zip(stats_headers, stats_channels):
         # Add empty columns to table
         beads_table[channel + ' Detector Volt.'] = np.nan
-        for row_id, sample in zip(beads_table.index, beads_samples):
+        beads_table[channel + ' Amp. Type'] = ""
+        if mef_outputs:
+            beads_table[channel + ' Bead Model Params.'] = ""
+
+        # Iterate
+        for i, row_id in enumerate(beads_table.index):
             # If MEF values are specified, calculate stats. If not, leave empty.
             if pd.notnull(beads_table[header][row_id]):
+
                 # Detector voltage
-                beads_table.set_value(row_id,
-                                      channel + ' Detector Volt.',
-                                      sample.detector_voltage(channel))
+                beads_table.set_value(
+                    row_id,
+                    channel + ' Detector Volt.',
+                    beads_samples[i].detector_voltage(channel))
+
                 # Amplification type
-                if sample.amplification_type(channel)[0]:
+                if beads_samples[i].amplification_type(channel)[0]:
                     amplification_type = "Log"
                 else:
                     amplification_type = "Linear"
                 beads_table.set_value(row_id,
                                       channel + ' Amp. Type',
                                       amplification_type)
+
+                # Bead model parameters
+                # Only populate if mef_outputs has been provided
+                if mef_outputs:
+                    # Try to find the current channel among the mef'd channels.
+                    # If successful, extract bead fitted parameters.
+                    try:
+                        mef_channel_index = mef_outputs[i]. \
+                            mef_channels.index(channel)
+                    except ValueError:
+                        pass
+                    else:
+                        params = mef_outputs[i]. \
+                            fitting['beads_params'][mef_channel_index]
+                        params_str = ", ".join([str(p) for p in params])
+                        beads_table.set_value(row_id,
+                                              channel + ' Bead Model Params.',
+                                              params_str)
+
 
 def add_samples_stats(samples_table, samples):
     """
@@ -939,13 +972,14 @@ def run(input_path=None, output_path=None, verbose=True, plot=True):
                                index_col='ID')
 
     # Process beads samples
-    beads_samples, mef_transform_fxns = process_beads_table(
+    beads_samples, mef_transform_fxns, mef_outputs = process_beads_table(
         beads_table,
         instruments_table,
         base_dir=input_dir,
         verbose=verbose,
         plot=plot,
-        plot_dir='plot_beads')
+        plot_dir='plot_beads',
+        full_output=True)
 
     # Process samples
     samples = process_samples_table(
@@ -961,7 +995,7 @@ def run(input_path=None, output_path=None, verbose=True, plot=True):
     if verbose:
         print("")
         print("Calculating statistics for beads...")
-    add_beads_stats(beads_table, beads_samples)
+    add_beads_stats(beads_table, beads_samples, mef_outputs)
 
     # Add stats to samples table
     if verbose:

--- a/FlowCal/excel_ui.py
+++ b/FlowCal/excel_ui.py
@@ -35,6 +35,13 @@ import FlowCal.mef
 re_mef_values = re.compile(r'^\s*(\S*)\s*MEF\s*Values\s*$')
 re_units = re.compile(r'^\s*(\S*)\s*Units\s*$')
 
+class ExcelUIException(Exception):
+    """
+    FlowCal Excel UI Error.
+
+    """
+    pass
+
 def read_table(filename, sheetname, index_col=None):
     """
     Return the contents of an Excel table as a pandas DataFrame.

--- a/FlowCal/excel_ui.py
+++ b/FlowCal/excel_ui.py
@@ -181,16 +181,16 @@ def process_beads_table(beads_table,
     mef_transform_fxns : OrderedDict
         A dictionary of MEF transformation functions, indexed by
         ``beads_table.index``.
-    mef_outputs : OrderedDict
-        A dictionary with the intermediate results of the generation of the
-        MEF transformation functions, indexed by ``beads_table.index``.
-        Only included if `full_output` is True.
+    mef_outputs : list
+        A list with intermediate results of the generation of the MEF
+        transformation functions, indexed by ``beads_table.index``. Only
+        included if `full_output` is True.
 
     """
     # Initialize output variables
     beads_samples = []
     mef_transform_fxns = collections.OrderedDict()
-    mef_outputs = collections.OrderedDict()
+    mef_outputs = []
 
     # Return empty structures if beads table is empty
     if beads_table.empty:
@@ -356,7 +356,7 @@ def process_beads_table(beads_table,
                 plot_dir=os.path.join(base_dir, plot_dir),
                 full_output=full_output)
             if full_output:
-                mef_outputs[beads_id] = mef_output
+                mef_outputs.append(mef_output)
                 mef_transform_fxns[beads_id] = mef_output.transform_fxn
             else:
                 mef_transform_fxns[beads_id] = mef_output

--- a/FlowCal/excel_ui.py
+++ b/FlowCal/excel_ui.py
@@ -251,7 +251,7 @@ def process_beads_table(beads_table,
             filename = os.path.join(base_dir, beads_row['File Path'])
             try:
                 beads_sample = FlowCal.io.FCSData(filename)
-            except:
+            except IOError:
                 raise ExcelUIException("file \"{}\" not found".format(
                     beads_row['File Path']))
             # Check that the number of events is greater than 500
@@ -526,7 +526,7 @@ def process_samples_table(samples_table,
             filename = os.path.join(base_dir, sample_row['File Path'])
             try:
                 sample = FlowCal.io.FCSData(filename)
-            except:
+            except IOError:
                 raise ExcelUIException("file \"{}\" not found".format(
                     sample_row['File Path']))
             # Check that the number of events is greater than 500

--- a/FlowCal/excel_ui.py
+++ b/FlowCal/excel_ui.py
@@ -248,7 +248,11 @@ def process_beads_table(beads_table,
                 print("Loading file \"{}\"...".format(beads_row['File Path']))
 
             filename = os.path.join(base_dir, beads_row['File Path'])
-            beads_sample = FlowCal.io.FCSData(filename)
+            try:
+                beads_sample = FlowCal.io.FCSData(filename)
+            except:
+                raise ExcelUIException("file \"{}\" not found".format(
+                    beads_row['File Path']))
 
             ###
             # Transform
@@ -505,7 +509,11 @@ def process_samples_table(samples_table,
                 print("Loading file \"{}\"...".format(sample_row['File Path']))
 
             filename = os.path.join(base_dir, sample_row['File Path'])
-            sample = FlowCal.io.FCSData(filename)
+            try:
+                sample = FlowCal.io.FCSData(filename)
+            except:
+                raise ExcelUIException("file \"{}\" not found".format(
+                    sample_row['File Path']))
 
             ###
             # Transform
@@ -889,6 +897,8 @@ def generate_histograms_table(samples_table, samples):
     # largest.
     n_columns = 0
     for sample_id, sample in zip(samples_table.index, samples):
+        if isinstance(sample, ExcelUIException):
+            continue
         for header, channel in zip(hist_headers, hist_channels):
             if pd.notnull(samples_table[header][sample_id]):
                 bins = sample.domain(channel)
@@ -903,6 +913,8 @@ def generate_histograms_table(samples_table, samples):
 
     # Generate histograms
     for sample_id, sample in zip(samples_table.index, samples):
+        if isinstance(sample, ExcelUIException):
+            continue
         for header, channel in zip(hist_headers, hist_channels):
             if pd.notnull(samples_table[header][sample_id]):
                 # Get units in which bins are being reported

--- a/FlowCal/excel_ui.py
+++ b/FlowCal/excel_ui.py
@@ -714,7 +714,7 @@ def add_beads_stats(beads_table, beads_samples, mef_outputs=None):
     Add stats fields to beads table.
 
     The following information is added to each row:
-        - Whether analysis was successful
+        - Notes (warnings, errors) resulting from the analysis
         - Number of Events
         - Acquisition Time (s)
 
@@ -743,22 +743,22 @@ def add_beads_stats(beads_table, beads_samples, mef_outputs=None):
 
     """
     # Add per-row info
-    success = []
+    notes = []
     n_events = []
     acq_time = []
     for beads_sample in beads_samples:
         # Check if sample is an exception, otherwise assume it's an FCSData
         if isinstance(beads_sample, ExcelUIException):
             # Print error message
-            success.append("ERROR: {}".format(str(beads_sample)))
+            notes.append("ERROR: {}".format(str(beads_sample)))
             n_events.append(np.nan)
             acq_time.append(np.nan)
         else:
-            success.append('Yes')
+            notes.append('')
             n_events.append(beads_sample.shape[0])
             acq_time.append(beads_sample.acquisition_time)
 
-    beads_table['Successful?'] = success
+    beads_table['Analysis Notes'] = notes
     beads_table['Number of Events'] = n_events
     beads_table['Acquisition Time (s)'] = acq_time
 
@@ -822,7 +822,7 @@ def add_samples_stats(samples_table, samples):
     Add stats fields to samples table.
 
     The following information is added to each row:
-        - Whether analysis was successful
+        - Notes (warnings, errors) resulting from the analysis
         - Number of Events
         - Acquisition Time (s)
     
@@ -851,22 +851,22 @@ def add_samples_stats(samples_table, samples):
 
     """
     # Add per-row info
-    success = []
+    notes = []
     n_events = []
     acq_time = []
     for sample in samples:
         # Check if sample is an exception, otherwise assume it's an FCSData
         if isinstance(sample, ExcelUIException):
             # Print error message
-            success.append("ERROR: {}".format(str(sample)))
+            notes.append("ERROR: {}".format(str(sample)))
             n_events.append(np.nan)
             acq_time.append(np.nan)
         else:
-            success.append('Yes')
+            notes.append('')
             n_events.append(sample.shape[0])
             acq_time.append(sample.acquisition_time)
 
-    samples_table['Successful?'] = success
+    samples_table['Analysis Notes'] = notes
     samples_table['Number of Events'] = n_events
     samples_table['Acquisition Time (s)'] = acq_time
 

--- a/FlowCal/mef.py
+++ b/FlowCal/mef.py
@@ -404,6 +404,9 @@ def get_transform_fxn(data_beads,
         general transformation function specified in ``FlowCal.transform``.
     namedtuple, if ``full_output==True``
         ``namedtuple``, containing the following fields in this order:
+        mef_channels : int, or str, or list of int, or list of str
+            Channels on which transformation functions have been generated.
+            Directly copied from the `mef_channels` argument.
         transform_fxn : function
             Transformation function to convert flow cytometry data from
             channel units to MEF. This function has the same basic
@@ -784,13 +787,15 @@ def get_transform_fxn(data_beads,
         fitting_res['beads_params'] = beads_params_res
 
         # Make namedtuple
-        fields = ['transform_fxn',
+        fields = ['mef_channels',
+                  'transform_fxn',
                   'clustering',
                   'statistic',
                   'selection',
                   'fitting']
         MEFOutput = collections.namedtuple('MEFOutput', fields, verbose=False)
-        out = MEFOutput(transform_fxn=transform_fxn,
+        out = MEFOutput(mef_channels=mef_channels,
+                        transform_fxn=transform_fxn,
                         clustering=clustering_res,
                         statistic=statistic_res,
                         selection=selection_res,

--- a/FlowCal/mef.py
+++ b/FlowCal/mef.py
@@ -217,6 +217,11 @@ def fit_beads_autofluorescence(fl_channel, fl_mef):
     beads_params : array
         Fitted parameters of the bead fluorescence model: ``[m, b,
         fl_mef_auto]``.
+    beads_model_str : str
+        String representation of the beads model used.
+    beads_params_names : list of str
+        Names of the parameters in a list, in the same order as they are
+        given in `beads_params`.
 
     Notes
     -----
@@ -289,8 +294,18 @@ def fit_beads_autofluorescence(fl_channel, fl_mef):
 
     # Standard curve function
     std_crv = lambda x: sc_fun(beads_params, x)
+
+    # Model string representation
+    beads_model_str = 'm*fl_ch + b = log(fl_mef_auto + fl_mef)'
+
+    # Parameter names
+    beads_params_names = ['m', 'b', 'fl_mef_auto']
     
-    return (std_crv, beads_model, beads_params)
+    return (std_crv,
+            beads_model,
+            beads_params,
+            beads_model_str,
+            beads_params_names)
 
 def plot_standard_curve(fl_channel,
                         fl_mef,
@@ -481,14 +496,18 @@ def get_transform_fxn(data_beads,
     fitting_fxn : function, optional
         Function used to fit the beads fluorescence model and obtain a
         standard curve. Must have the following signature: ``std_crv,
-        beads_model, beads_params = fitting_fxn(fl_channel, fl_mef,
-        **fitting_params)``, where `std_crv` is a function implementing the
-        standard curve, `beads_model` is a function implementing the beads
-        fluorescence model, `beads_params` is an array containing the
-        fitted parameters of the beads model, and `fl_channel` and `fl_mef`
-        are the fluorescence values of the beads in channel units and MEF
-        units, respectively. Note that the standard curve and the fitted
-        beads model are not necessarily the same.
+        beads_model, beads_params, beads_model_str, beads_params_names =
+        fitting_fxn(fl_channel, fl_mef, **fitting_params)``, where
+        `std_crv` is a function implementing the standard curve,
+        `beads_model` is a function implementing the beads fluorescence
+        model, `beads_params` is an array containing the fitted parameters
+        of the beads model, `beads_model_str` is a string representation
+        of the beads model used, `beads_params_names` is a list with the
+        parameter names in the same order as they are given in
+        `beads_params`, and `fl_channel` and `fl_mef` are the fluorescence
+        values of the beads in channel units and MEF units, respectively.
+        Note that the standard curve and the fitted beads model are not
+        necessarily the same.
     fitting_params : dict, optional
         Additional keyword parameters to pass to `fitting_fxn`.
 
@@ -621,6 +640,8 @@ def get_transform_fxn(data_beads,
         selected_mef_res = []
         beads_model_res = []
         beads_params_res =[]
+        beads_model_str_res =[]
+        beads_params_names_res =[]
 
     # Iterate through each mef channel
     for mef_channel, mef_values_channel in zip(mef_channels, mef_values):
@@ -720,15 +741,21 @@ def get_transform_fxn(data_beads,
         ###
 
         # Fit
-        std_crv, beads_model, beads_params = fitting_fxn(
-            selected_channel,
-            selected_mef,
-            **fitting_params)
+        fitting_output = fitting_fxn(selected_channel,
+                                     selected_mef,
+                                     **fitting_params)
+        std_crv = fitting_output[0]
+        beads_model = fitting_output[1]
+        beads_params = fitting_output[2]
+        beads_model_str = fitting_output[3]
+        beads_params_names = fitting_output[4]
         # Accumulate results
         std_crv_res.append(std_crv)
         if full_output:
             beads_model_res.append(beads_model)
             beads_params_res.append(beads_params)
+            beads_model_str_res.append(beads_model_str)
+            beads_params_names_res.append(beads_params_names)
 
         # Print information
         if verbose:
@@ -785,6 +812,8 @@ def get_transform_fxn(data_beads,
         fitting_res['std_crv'] = std_crv_res
         fitting_res['beads_model'] = beads_model_res
         fitting_res['beads_params'] = beads_params_res
+        fitting_res['beads_model_str'] = beads_model_str_res
+        fitting_res['beads_params_names'] = beads_params_names_res
 
         # Make namedtuple
         fields = ['mef_channels',


### PR DESCRIPTION
Addresses #184, #126, #99, #98, #65, and #38, and probably some more. It would potentially handle #130, although we now want to support linear amplifiers.

Introduces handling of (some) exceptions without crashing. Examples of things that are now covered are:
- missing file path
- MEF transformation requested in a channel for which a standard curve does not exist
- low number of events
- acquisition settings of beads and samples are different

Instead of crashing, the Excel UI now aborts execution of the current sample and prints the error to both the console (if verbose mode is on) and the Excel output file, column "Successful?".

This has the interesting side effect that some of our example files are no longer valid, since some beads and samples have not been acquired at the same detector voltage.
