### PR TITLE
Changed gate.start_end() behavior with num_end=0

### DIFF
--- a/FlowCal/gate.py
+++ b/FlowCal/gate.py
@@ -39,6 +39,7 @@ def start_end(data, num_start=250, num_end=100, full_output=False):
         the number of parameters (aka channels).
     num_start, num_end : int, optional
         Number of events to gate out from beginning and end of `data`.
+        Ignored if less than 0.
     full_output : bool, optional
         Flag specifying to return additional outputs. If true, the outputs
         are given as a namedtuple.
@@ -58,13 +59,22 @@ def start_end(data, num_start=250, num_end=100, full_output=False):
         number of events in `data`.
 
     """
+
+    if num_start < 0:
+        num_start = 0
+    if num_end < 0:
+        num_end = 0
+
     if data.shape[0] < (num_start + num_end):
         raise ValueError('Number of events to discard greater than total' + 
             ' number of events.')
     
     mask = np.ones(shape=data.shape[0],dtype=bool)
     mask[:num_start] = False
-    mask[-num_end:] = False
+    if num_end > 0:
+        # catch the edge case where `num_end=0` causes mask[-num_end:] to mask
+        # off all events
+        mask[-num_end:] = False
     gated_data = data[mask]
 
     if full_output:

--- a/test/test_gate.py
+++ b/test/test_gate.py
@@ -55,6 +55,44 @@ class TestStartEndGate(unittest.TestCase):
             np.array([0,0,1,1,1,1,1,0,0,0], dtype=bool)
             )
 
+    def test_0_end_gated_data_1(self):
+        np.testing.assert_array_equal(
+            FlowCal.gate.start_end(self.d, num_start=2, num_end=0),
+            np.array([
+                [3, 9, 4],
+                [4, 10, 5],
+                [5, 1, 6],
+                [6, 2, 7],
+                [7, 3, 8],
+                [8, 4, 9],
+                [9, 5, 10],
+                [10, 6, 1],
+                ])
+            )
+
+    def test_0_end_gated_data_2(self):
+        np.testing.assert_array_equal(
+            FlowCal.gate.start_end(
+                self.d, num_start=2, num_end=0, full_output=True).gated_data,
+            np.array([
+                [3, 9, 4],
+                [4, 10, 5],
+                [5, 1, 6],
+                [6, 2, 7],
+                [7, 3, 8],
+                [8, 4, 9],
+                [9, 5, 10],
+                [10, 6, 1],
+                ])
+            )
+
+    def test_0_end_mask(self):
+        np.testing.assert_array_equal(
+            FlowCal.gate.start_end(
+                self.d, num_start=2, num_end=0, full_output=True).mask,
+            np.array([0,0,1,1,1,1,1,1,1,1], dtype=bool)
+            )
+
     def test_error(self):
         with self.assertRaises(ValueError):
             FlowCal.gate.start_end(self.d, num_start=5, num_end=7)


### PR DESCRIPTION
Fixes #224.

Added 3 unit tests to test for this edge case (see c929056f38d056b29f464cec0e7ebe4450b1cf5a).

Current `develop` branch (919ec0355fe7febea9972166ce35d49150f63dce) fails these unit tests:
```
python -m unittest discover
...........................................................................................FFF.............................................................................................................................................................................................
======================================================================
FAIL: test_0_end_gated_data_1 (test.test_gate.TestStartEndGate)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\sexto\Documents\GitHub\FlowCal\test\test_gate.py", line 69, in test_0_end_gated_data_1
    [10, 6, 1],
  File "C:\Users\sexto\Anaconda2\lib\site-packages\numpy\testing\utils.py", line 811, in assert_array_equal
    verbose=verbose, header='Arrays are not equal')
  File "C:\Users\sexto\Anaconda2\lib\site-packages\numpy\testing\utils.py", line 692, in assert_array_compare
    raise AssertionError(msg)
AssertionError:
Arrays are not equal

(shapes (0L, 3L), (8L, 3L) mismatch)
 x: array([], shape=(0L, 3L), dtype=int32)
 y: array([[ 3,  9,  4],
       [ 4, 10,  5],
       [ 5,  1,  6],...

======================================================================
FAIL: test_0_end_gated_data_2 (test.test_gate.TestStartEndGate)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\sexto\Documents\GitHub\FlowCal\test\test_gate.py", line 85, in test_0_end_gated_data_2
    [10, 6, 1],
  File "C:\Users\sexto\Anaconda2\lib\site-packages\numpy\testing\utils.py", line 811, in assert_array_equal
    verbose=verbose, header='Arrays are not equal')
  File "C:\Users\sexto\Anaconda2\lib\site-packages\numpy\testing\utils.py", line 692, in assert_array_compare
    raise AssertionError(msg)
AssertionError:
Arrays are not equal

(shapes (0L, 3L), (8L, 3L) mismatch)
 x: array([], shape=(0L, 3L), dtype=int32)
 y: array([[ 3,  9,  4],
       [ 4, 10,  5],
       [ 5,  1,  6],...

======================================================================
FAIL: test_0_end_mask (test.test_gate.TestStartEndGate)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\sexto\Documents\GitHub\FlowCal\test\test_gate.py", line 93, in test_0_end_mask
    np.array([0,0,1,1,1,1,1,1,1,1], dtype=bool)
  File "C:\Users\sexto\Anaconda2\lib\site-packages\numpy\testing\utils.py", line 811, in assert_array_equal
    verbose=verbose, header='Arrays are not equal')
  File "C:\Users\sexto\Anaconda2\lib\site-packages\numpy\testing\utils.py", line 737, in assert_array_compare
    raise AssertionError(msg)
AssertionError:
Arrays are not equal

(mismatch 80.0%)
 x: array([False, False, False, False, False, False, False, False, False, False], dtype=bool)
 y: array([False, False,  True,  True,  True,  True,  True,  True,  True,  True], dtype=bool)

----------------------------------------------------------------------
Ran 283 tests in 5.294s

FAILED (failures=3)
```

Implemented fix (see b1256884f3260c68a1a4a359779f18b1eed54804). All unit tests pass:
```
python -m unittest discover
...........................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 283 tests in 5.686s

OK
```