### PR TITLE
Removed duplicate color argument in plot.scatter3d.

### DIFF
--- a/FlowCal/plot.py
+++ b/FlowCal/plot.py
@@ -1330,7 +1330,6 @@ def scatter3d(data_list,
                       marker='o',
                       alpha=0.1,
                       color=color[i],
-                      c=color[i],
                       **kwargs)
 
     # Remove tick labels


### PR DESCRIPTION
Solves #225.

Unit tests pass.

Excel UI now runs properly with matplotlib 1.5.3, when 3 channels have been specified for clustering, and scatter plot looks as expected.

Also works with matplotlib 1.3.1 (minimum version recommended).