### PR TITLE
FCSData imports FCS file when $PnV keyword is 'NA'

### DIFF
--- a/FlowCal/io.py
+++ b/FlowCal/io.py
@@ -1523,9 +1523,12 @@ class FCSData(np.ndarray):
                    and 'CellQuest Pro' in fcs_file.text.get('CREATOR'):
                 channel_detector_voltage = fcs_file.text.get('BD$WORD{}' \
                                                              .format(12+i))
+            if channel_detector_voltage is not None:
+                try:
+                    channel_detector_voltage = float(channel_detector_voltage)
+                except ValueError:
+                    channel_detector_voltage = None
             detector_voltage.append(channel_detector_voltage)
-        detector_voltage = [float(dvi) if dvi is not None else None
-                            for dvi in detector_voltage]
         detector_voltage = tuple(detector_voltage)
 
         # Amplifier gain: Stored in the keyword parameter $PnG for channel n.
@@ -1539,9 +1542,12 @@ class FCSData(np.ndarray):
             if channel_amp_gain is None and 'CREATOR' in fcs_file.text and \
                     'FlowJoCollectorsEdition' in fcs_file.text.get('CREATOR'):
                 channel_amp_gain = fcs_file.text.get('CytekP{:02d}G'.format(i))
+            if channel_amp_gain is not None:
+                try:
+                    channel_amp_gain = float(channel_amp_gain)
+                except ValueError:
+                    channel_amp_gain = None
             amplifier_gain.append(channel_amp_gain)
-        amplifier_gain = [float(agi) if agi is not None else None
-                          for agi in amplifier_gain]
         amplifier_gain = tuple(amplifier_gain)
 
         # Get data from fcs_file object, and change writeable flag.

--- a/FlowCal/io.py
+++ b/FlowCal/io.py
@@ -1512,16 +1512,18 @@ class FCSData(np.ndarray):
         resolution = tuple(resolution)
 
         # Detector voltage: Stored in the keyword parameter $PnV for channel n.
-        # The CellQuest Pro software saves the detector voltage in keyword
-        # parameters BD$WORD13, BD$WORD14, BD$WORD15... for channels 1, 2,
-        # 3...
-        if 'CREATOR' in fcs_file.text and \
-                'CellQuest Pro' in fcs_file.text.get('CREATOR'):
-            detector_voltage = [fcs_file.text.get('BD$WORD{}'.format(12 + i))
-                                for i in range(1, num_channels + 1)]
-        else:
-            detector_voltage = [fcs_file.text.get('$P{}V'.format(i))
-                            for i in range(1, num_channels + 1)]
+        detector_voltage = []
+        for i in range(1, num_channels + 1):
+            channel_detector_voltage = fcs_file.text.get('$P{}V'.format(i))
+
+            # The CellQuest Pro software saves the detector voltage in keyword
+            # parameters BD$WORD13, BD$WORD14, BD$WORD15... for channels 1, 2,
+            # 3...
+            if channel_detector_voltage is None and 'CREATOR' in fcs_file.text \
+                   and 'CellQuest Pro' in fcs_file.text.get('CREATOR'):
+                channel_detector_voltage = fcs_file.text.get('BD$WORD{}' \
+                                                             .format(12+i))
+            detector_voltage.append(channel_detector_voltage)
         detector_voltage = [float(dvi) if dvi is not None else None
                             for dvi in detector_voltage]
         detector_voltage = tuple(detector_voltage)

--- a/FlowCal/io.py
+++ b/FlowCal/io.py
@@ -1523,6 +1523,10 @@ class FCSData(np.ndarray):
                    and 'CellQuest Pro' in fcs_file.text.get('CREATOR'):
                 channel_detector_voltage = fcs_file.text.get('BD$WORD{}' \
                                                              .format(12+i))
+
+            # Attempt to cast extracted value to float
+            # The FCS3.1 standard restricts $PnV to be a floating-point value
+            # only. Any value that cannot be casted will be replaced with None.
             if channel_detector_voltage is not None:
                 try:
                     channel_detector_voltage = float(channel_detector_voltage)
@@ -1542,6 +1546,10 @@ class FCSData(np.ndarray):
             if channel_amp_gain is None and 'CREATOR' in fcs_file.text and \
                     'FlowJoCollectorsEdition' in fcs_file.text.get('CREATOR'):
                 channel_amp_gain = fcs_file.text.get('CytekP{:02d}G'.format(i))
+
+            # Attempt to cast extracted value to float
+            # The FCS3.1 standard restricts $PnG to be a floating-point value
+            # only. Any value that cannot be casted will be replaced with None.
             if channel_amp_gain is not None:
                 try:
                     channel_amp_gain = float(channel_amp_gain)


### PR DESCRIPTION
Fixes #227.

All unit tests pass.

I also tested this bug fix against the repository of FCS files here: https://flowrepository.org/id/FR-FCM-ZZZ4

and against some in-house files:
* `FC1.fcs` - FCS 2.0 from CellQuest Pro 5.1.1 / BD FACScan Flow Cytometer
* `FC2.fcs` - FCS 3.0 from FlowJo Collectors Edition 7.5 / BD FACScan Flow Cytometer
* `FC2_3-5_gain.fcs` - FCS 3.0 from FlowJo Collectors Edition 7.5 / BD FACScan Flow Cytometer
  * I know the linear amplifier gain on this file was changed to 3.5 for one of the channels.
* `FC3.fcs` - file from the offending Attune NxT cytometer

using the following script:
```python
import FlowCal as fc
import os

dirs = ['flow_repo', 'in_house']

for d in dirs:
    for idx, f in enumerate(os.listdir(d)):
        print(d,idx,f)
        try:
            data = fc.io.FCSData(os.path.join(d,f))
            print(' - imported successfully...')
        except:
            print(' - failed to import...')
            continue
        print(' - CREATOR:{}'.format(data.text.get('CREATOR')))
        print(' - detector voltage:{}'.format(data.detector_voltage()))
        print(' - amplifier gain:  {}'.format(data.amplifier_gain()))
```
on the `develop` branch (42cd28d) and on the proposed fix (4e9e98f). I used an online diff tool to compare the outputs, and only one file showed any differences:

![42cd28d_4e9e98f](https://cloud.githubusercontent.com/assets/2179825/21633513/853c891c-d215-11e6-9f22-d5df2b4e1a74.PNG)

That one file (`FC3.fcs`) is a file from the Attune NxT cytometer which originally highlighted this bug. This bug fix appears to be working as expected.