### PR TITLE
Updated Excel UI column parsing regex.

### DIFF
--- a/FlowCal/excel_ui.py
+++ b/FlowCal/excel_ui.py
@@ -92,8 +92,8 @@ import FlowCal.stats
 import FlowCal.mef
 
 # Regular expressions for headers that specify some fluorescence channel
-re_mef_values = re.compile(r'^\s*(\S*)\s*MEF\s*Values\s*$')
-re_units = re.compile(r'^\s*(\S*)\s*Units\s*$')
+re_mef_values = re.compile(r'^\s*(\S(.*\S)*)\s*MEF\s*Values\s*$')
+re_units      = re.compile(r'^\s*(\S(.*\S)*)\s*Units\s*$')
 
 class ExcelUIException(Exception):
     """
@@ -310,7 +310,7 @@ def process_beads_table(beads_table,
     # Extract header and channel names for which MEF values are specified.
     headers = list(beads_table.columns)
     mef_headers_all = [h for h in headers if re_mef_values.match(h)]
-    mef_channels_all = [re_mef_values.search(h).group(1)
+    mef_channels_all = [re_mef_values.match(h).group(1)
                         for h in mef_headers_all]
 
     # Iterate through table
@@ -620,7 +620,7 @@ def process_samples_table(samples_table,
     # Extract header and channel names for which units are specified.
     headers = list(samples_table.columns)
     report_headers_all = [h for h in headers if re_units.match(h)]
-    report_channels_all = [re_units.search(h).group(1)
+    report_channels_all = [re_units.match(h).group(1)
                            for h in report_headers_all]
 
     # Iterate through table
@@ -913,7 +913,7 @@ def add_beads_stats(beads_table, beads_samples, mef_outputs=None):
     # List of channels that require stats columns
     headers = list(beads_table.columns)
     stats_headers = [h for h in headers if re_mef_values.match(h)]
-    stats_channels = [re_mef_values.search(h).group(1) for h in stats_headers]
+    stats_channels = [re_mef_values.match(h).group(1) for h in stats_headers]
 
     # Iterate through channels
     for header, channel in zip(stats_headers, stats_channels):
@@ -1057,7 +1057,7 @@ def add_samples_stats(samples_table, samples):
     # List of channels that require stats columns
     headers = list(samples_table.columns)
     stats_headers = [h for h in headers if re_units.match(h)]
-    stats_channels = [re_units.search(h).group(1) for h in stats_headers]
+    stats_channels = [re_units.match(h).group(1) for h in stats_headers]
 
     # Iterate through channels
     for header, channel in zip(stats_headers, stats_channels):
@@ -1181,7 +1181,7 @@ def generate_histograms_table(samples_table, samples, max_bins=1024):
     # Extract channels that require stats histograms
     headers = list(samples_table.columns)
     hist_headers = [h for h in headers if re_units.match(h)]
-    hist_channels = [re_units.search(h).group(1) for h in hist_headers]
+    hist_channels = [re_units.match(h).group(1) for h in hist_headers]
 
     # The number of columns in the DataFrame has to be set to the maximum
     # number of bins of any of the histograms about to be generated.


### PR DESCRIPTION
Updated Excel UI column parsing regex.
Fixes #250.

### Updated RegEx
old:
```python
re_mef_values = re.compile(r'^\s*(\S*)\s*MEF\s*Values\s*$')
re_units = re.compile(r'^\s*(\S*)\s*Units\s*$')
```

new:
```python
re_mef_values = re.compile(r'^\s*(\S(.*\S)*)\s*MEF\s*Values\s*$')
re_units      = re.compile(r'^\s*(\S(.*\S)*)\s*Units\s*$')
```

To test these regexs, I ran the following script (`regex_test.py`):
```python
import re

regexs = []
regexs.append(re.compile(r'^\s*(\S*)\s*Units\s*$'))        # current, doesn't tolerate spaces
regexs.append(re.compile(r'^\s*(\S.*\S)\s*Units\s*$'))     # tolerates spaces but requires 2 chars
regexs.append(re.compile(r'^\s*(\S(.*\S)*)\s*Units\s*$'))  # tolerates spaces, does not require 2 chars

with open('units_strings.txt', 'r') as f:
    for line in f:
        test_string = line.rstrip('\n')
        print('string: >'+test_string+'<')
        for r in regexs:
            print(' regex: '+r.pattern)
            m = r.match(test_string)
            if m:
                print(' groups: '+str(m.groups()))
            else:
                print(' no match')
        print('')
```

on the following list of strings (`units_strings.txt`):
```
Units
 Units
  Units
 Units 
test Units
Parameter 14
1 Units
13 Units
Parameter 14 Units
  here is another test of Units
  test test Units
```
and got the following output:
```
>python regex_test.py
string: >Units<
 regex: ^\s*(\S*)\s*Units\s*$
 groups: ('',)
 regex: ^\s*(\S.*\S)\s*Units\s*$
 no match
 regex: ^\s*(\S(.*\S)*)\s*Units\s*$
 no match

string: > Units<
 regex: ^\s*(\S*)\s*Units\s*$
 groups: ('',)
 regex: ^\s*(\S.*\S)\s*Units\s*$
 no match
 regex: ^\s*(\S(.*\S)*)\s*Units\s*$
 no match

string: >  Units<
 regex: ^\s*(\S*)\s*Units\s*$
 groups: ('',)
 regex: ^\s*(\S.*\S)\s*Units\s*$
 no match
 regex: ^\s*(\S(.*\S)*)\s*Units\s*$
 no match

string: > Units <
 regex: ^\s*(\S*)\s*Units\s*$
 groups: ('',)
 regex: ^\s*(\S.*\S)\s*Units\s*$
 no match
 regex: ^\s*(\S(.*\S)*)\s*Units\s*$
 no match

string: >test Units<
 regex: ^\s*(\S*)\s*Units\s*$
 groups: ('test',)
 regex: ^\s*(\S.*\S)\s*Units\s*$
 groups: ('test',)
 regex: ^\s*(\S(.*\S)*)\s*Units\s*$
 groups: ('test', 'est')

string: >Parameter 14<
 regex: ^\s*(\S*)\s*Units\s*$
 no match
 regex: ^\s*(\S.*\S)\s*Units\s*$
 no match
 regex: ^\s*(\S(.*\S)*)\s*Units\s*$
 no match

string: >1 Units<
 regex: ^\s*(\S*)\s*Units\s*$
 groups: ('1',)
 regex: ^\s*(\S.*\S)\s*Units\s*$
 no match
 regex: ^\s*(\S(.*\S)*)\s*Units\s*$
 groups: ('1', None)

string: >13 Units<
 regex: ^\s*(\S*)\s*Units\s*$
 groups: ('13',)
 regex: ^\s*(\S.*\S)\s*Units\s*$
 groups: ('13',)
 regex: ^\s*(\S(.*\S)*)\s*Units\s*$
 groups: ('13', '3')

string: >Parameter 14 Units<
 regex: ^\s*(\S*)\s*Units\s*$
 no match
 regex: ^\s*(\S.*\S)\s*Units\s*$
 groups: ('Parameter 14',)
 regex: ^\s*(\S(.*\S)*)\s*Units\s*$
 groups: ('Parameter 14', 'arameter 14')

string: >  here is another test of Units<
 regex: ^\s*(\S*)\s*Units\s*$
 no match
 regex: ^\s*(\S.*\S)\s*Units\s*$
 groups: ('here is another test of',)
 regex: ^\s*(\S(.*\S)*)\s*Units\s*$
 groups: ('here is another test of', 'ere is another test of')

string: >  test test Units<
 regex: ^\s*(\S*)\s*Units\s*$
 no match
 regex: ^\s*(\S.*\S)\s*Units\s*$
 groups: ('test test',)
 regex: ^\s*(\S(.*\S)*)\s*Units\s*$
 groups: ('test test', 'est test')
```
Note:
- correctly pulls out channel names with spaces (and eliminates leading and trailing spaces before and after channel name, which is important for downstream usage of that channel label)
- works as expected on channel names with only 1 character
- strings with lots of leading white space no longer generate a `MatchObject` (see first 4 test strings). Practically speaking, I believe this simply means that such columns/channels are ignored [here (L622)](https://github.com/taborlab/FlowCal/blob/4420e15428d13923e8da32f85ae7676adfeade81/FlowCal/excel_ui.py#L622) instead of somewhere after [here (L674)](https://github.com/taborlab/FlowCal/blob/4420e15428d13923e8da32f85ae7676adfeade81/FlowCal/excel_ui.py#L674), so I don't think this is a problem.


### `re.search()` vs. `re.match()`
Only mildly related: I also updated all the `re.search()` calls to `re.match()` calls. [`search()` and `match()` do different things](https://docs.python.org/2/library/re.html#search-vs-match), and I couldn't think of a reason to `match()` in the first line and `search()` in the second line. To the contrary, it seemed better if the same operation was being performed in both instances (the same little block of code exists in several places which first filters channel headers and then extracts the channel name. That code could possibly be optimized to eliminate one of the `re.match()` calls, too? Seems like the work to create the MatchObject is being done twice unnecessarily). If I've overlooked something, though, lemme know and we can change it back.