### PR TITLE
Better support for supplemental TEXT segments.

### DIFF
--- a/FlowCal/io.py
+++ b/FlowCal/io.py
@@ -107,7 +107,7 @@ def read_fcs_text_segment(buf, begin, end, delim=None):
         Offset (in bytes) to last byte of TEXT segment in `buf`.
     delim : str, optional
         1-byte delimiter character which delimits key-value entries of
-        TEXT segment. If None, will extract delimter as first byte
+        TEXT segment. If None, will extract delimiter as first byte
         of TEXT segment.
 
     Returns
@@ -242,7 +242,7 @@ def read_fcs_text_segment(buf, begin, end, delim=None):
                     # consumed as the initial delimiter which a primary TEXT
                     # segment is required to start with. After that delimiter
                     # is accounted for, you now have either an unescaped
-                    # delimter, which is prohibited, or a boundary delimiter,
+                    # delimiter, which is prohibited, or a boundary delimiter,
                     # which would imply that the entire first keyword was
                     # composed of delimiters, which is prohibited because
                     # keywords are not allowed to start with the delimiter).
@@ -290,12 +290,12 @@ def read_fcs_text_segment(buf, begin, end, delim=None):
                     # number of delimiters.
                     #
                     # The accumulator should always have at least 1 element in
-                    # it. If it doesn't, the last value ends with the
-                    # delimiter, which will result in two consecutive empty
-                    # elements, which won't fall into this case. Only 1 empty
-                    # element indicates an ill-formed TEXT segment with an
-                    # unpaired non-boundary delimiter (e.g. /k1/v1//), which
-                    # is not permitted.
+                    # it at this point. If it doesn't, the last value ends
+                    # with the delimiter, which will result in two consecutive
+                    # empty elements, which won't fall into this case. Only 1
+                    # empty element indicates an ill-formed TEXT segment with
+                    # an unpaired non-boundary delimiter (e.g. /k1/v1//),
+                    # which is not permitted.
                     if len(reconstructed_KV_accumulator) == 0:
                         raise ValueError("ill-formed TEXT segment")
                     reconstructed_KV_accumulator[-1] = pairs_list[idx] + \

--- a/FlowCal/io.py
+++ b/FlowCal/io.py
@@ -657,7 +657,7 @@ class FCSFile(object):
         If $BYTEORD is not big endian ('4,3,2,1' or '2,1') or little
         endian ('1,2,3,4', '1,2').
     ValueError
-        If TEXT-like segment does not start with delimiter.
+        If primary TEXT segment does not start with delimiter.
     ValueError
         If TEXT-like segment has odd number of total extracted keys and
         values (indicating an unpaired key or value).
@@ -738,7 +738,8 @@ class FCSFile(object):
         self._text, delim = read_fcs_text_segment(
             buf=f,
             begin=self._header.text_begin,
-            end=self._header.text_end)
+            end=self._header.text_end,
+            supplemental=False)
 
         if self._header.version in ('FCS3.0','FCS3.1'):
             stext_begin = int(self._text['$BEGINSTEXT'])   # required keyword
@@ -748,7 +749,8 @@ class FCSFile(object):
                     buf=f,
                     begin=stext_begin,
                     end=stext_end,
-                    delim=delim)[0]
+                    delim=delim,
+                    supplemental=True)[0]
                 self._text.update(stext)
 
         # Confirm FCS file assumptions. All queried keywords are required
@@ -795,7 +797,8 @@ class FCSFile(object):
                     buf=f,
                     begin=self._header.analysis_begin,
                     end=self._header.analysis_end,
-                    delim=delim)[0]
+                    delim=delim,
+                    supplemental=True)[0]
             except Exception as e:
                 warnings.warn("ANALYSIS segment could not be parsed ({})".\
                     format(str(e)))
@@ -809,7 +812,8 @@ class FCSFile(object):
                         buf=f,
                         begin=analysis_begin,
                         end=analysis_end,
-                        delim=delim)[0]
+                        delim=delim,
+                        supplemental=True)[0]
                 except Exception as e:
                     warnings.warn("ANALYSIS segment could not be parsed ({})".\
                         format(str(e)))

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -528,8 +528,902 @@ class TestReadTextSegment(unittest.TestCase):
     ###
     # Supplemental TEXT Segment Tests
     ###
+    
+    def test_supp_one_key_value(self):
+        """
+        Test that typical supplemental TEXT segment is read correctly.
+        
+        """
+        raw_text_segment = '/k1/v1/'
+        delim            = '/'
+        text_dict        = {'k1':'v1'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
 
-    #TODO
+    def test_supp_one_key_value_s(self):
+        """
+        Test that typical supplemental TEXT segment is read correctly.
+        
+        """
+        raw_text_segment = 'k1/v1/'
+        delim            = '/'
+        text_dict        = {'k1':'v1'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_no_delim_fail(self):
+        """
+        Test failure when no delimiter is specified for supplemental segment.
+        
+        """
+        raw_text_segment = '/k1/v1/'
+        delim            = '/'
+        text_dict        = {'k1':'v1'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertRaises(
+            ValueError,
+            FlowCal.io.read_fcs_text_segment,
+            buf=buf, begin=0, end=len(raw_text_segment)-1, supplemental=True)
+
+    def test_supp_three_key_value(self):
+        """
+        Test that typical supplemental TEXT segment is read correctly.
+
+        """
+        raw_text_segment = '/k1/v1/k2/v2/k3/v3/'
+        delim            = '/'
+        text_dict        = {'k1':'v1','k2':'v2','k3':'v3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_three_key_value_s(self):
+        """
+        Test that typical supplemental TEXT segment is read correctly.
+
+        """
+        raw_text_segment = 'k1/v1/k2/v2/k3/v3/'
+        delim            = '/'
+        text_dict        = {'k1':'v1','k2':'v2','k3':'v3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_extra_trailing_chars(self):
+        """
+        Test that extra trailing characters still parse correctly.
+
+        Test that supplemental TEXT segment still parses correctly even if
+        there are trailing characters after the last instance of the delimiter.
+
+        """
+        raw_text_segment = '/k1/v1/     '
+        delim            = '/'
+        text_dict        = {'k1':'v1'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_extra_trailing_chars_s(self):
+        """
+        Test that extra trailing characters still parse correctly.
+
+        Test that supplemental TEXT segment still parses correctly even if
+        there are trailing characters after the last instance of the delimiter.
+
+        """
+        raw_text_segment = 'k1/v1/     '
+        delim            = '/'
+        text_dict        = {'k1':'v1'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_delim_in_keyword_1(self):
+        """
+        Test that delimiter in keyword still parses correctly.
+        
+        """
+        raw_text_segment = '/key//1/value1/k2/v2/k3/v3/'
+        delim            = '/'
+        text_dict        = {'key/1':'value1','k2':'v2','k3':'v3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_delim_in_keyword_1_s(self):
+        """
+        Test that delimiter in keyword still parses correctly.
+        
+        """
+        raw_text_segment = 'key//1/value1/k2/v2/k3/v3/'
+        delim            = '/'
+        text_dict        = {'key/1':'value1','k2':'v2','k3':'v3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_delim_in_value_1(self):
+        """
+        Test that delimiter in keyword value still parses correctly.
+        
+        """
+        raw_text_segment = '/key1/value//1/k2/v2/k3/v3/'
+        delim            = '/'
+        text_dict        = {'key1':'value/1','k2':'v2','k3':'v3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_delim_in_value_1_s(self):
+        """
+        Test that delimiter in keyword value still parses correctly.
+        
+        """
+        raw_text_segment = 'key1/value//1/k2/v2/k3/v3/'
+        delim            = '/'
+        text_dict        = {'key1':'value/1','k2':'v2','k3':'v3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_delim_in_keyword_2(self):
+        """
+        Test that delimiter in keyword still parses correctly.
+        
+        """
+        raw_text_segment = '/k1/v1/key//2/value2/k3/v3/'
+        delim            = '/'
+        text_dict        = {'k1':'v1','key/2':'value2','k3':'v3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_delim_in_keyword_2_s(self):
+        """
+        Test that delimiter in keyword still parses correctly.
+        
+        """
+        raw_text_segment = 'k1/v1/key//2/value2/k3/v3/'
+        delim            = '/'
+        text_dict        = {'k1':'v1','key/2':'value2','k3':'v3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_delim_in_value_2(self):
+        """
+        Test that delimiter in keyword value still parses correctly.
+        
+        """
+        raw_text_segment = '/k1/v1/key2/value//2/k3/v3/'
+        delim            = '/'
+        text_dict        = {'k1':'v1','key2':'value/2','k3':'v3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_delim_in_value_2_s(self):
+        """
+        Test that delimiter in keyword value still parses correctly.
+        
+        """
+        raw_text_segment = 'k1/v1/key2/value//2/k3/v3/'
+        delim            = '/'
+        text_dict        = {'k1':'v1','key2':'value/2','k3':'v3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_delim_in_keyword_3(self):
+        """
+        Test that delimiter in keyword still parses correctly.
+        
+        """
+        raw_text_segment = '/k1/v1/k2/v2/key//3/value3/'
+        delim            = '/'
+        text_dict        = {'k1':'v1','k2':'v2','key/3':'value3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_delim_in_keyword_3_s(self):
+        """
+        Test that delimiter in keyword still parses correctly.
+        
+        """
+        raw_text_segment = 'k1/v1/k2/v2/key//3/value3/'
+        delim            = '/'
+        text_dict        = {'k1':'v1','k2':'v2','key/3':'value3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_delim_in_value_3(self):
+        """
+        Test that delimiter in keyword value still parses correctly.
+        
+        """
+        raw_text_segment = '/k1/v1/k2/v2/key3/value//3/'
+        delim            = '/'
+        text_dict        = {'k1':'v1','k2':'v2','key3':'value/3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_delim_in_value_3_s(self):
+        """
+        Test that delimiter in keyword value still parses correctly.
+        
+        """
+        raw_text_segment = 'k1/v1/k2/v2/key3/value//3/'
+        delim            = '/'
+        text_dict        = {'k1':'v1','k2':'v2','key3':'value/3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_first_keyword_delim_fail(self):
+        """
+        Test that delimiter at start of first keyword fails.
+        
+        """
+        raw_text_segment = '///key1/value1/k2/v2/k3/v3/'
+        delim            = '/'
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertRaises(
+            ValueError,
+            FlowCal.io.read_fcs_text_segment,
+            buf=buf, begin=0, end=len(raw_text_segment)-1, delim=delim,
+                supplemental=True)
+
+    def test_supp_first_keyword_delim_fail_s(self):
+        """
+        Test that delimiter at start of first keyword fails.
+        
+        """
+        raw_text_segment = '//key1/value1/k2/v2/k3/v3/'
+        delim            = '/'
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertRaises(
+            ValueError,
+            FlowCal.io.read_fcs_text_segment,
+            buf=buf, begin=0, end=len(raw_text_segment)-1, delim=delim,
+                supplemental=True)
+
+    def test_supp_delim_in_keyword_4(self):
+        """
+        Test that delimiter in keyword still parses correctly.
+        
+        """
+        raw_text_segment = '/key1///value1/k2/v2/k3/v3/'
+        delim            = '/'
+        text_dict        = {'key1/':'value1','k2':'v2','k3':'v3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_delim_in_keyword_4_s(self):
+        """
+        Test that delimiter in keyword still parses correctly.
+        
+        """
+        raw_text_segment = 'key1///value1/k2/v2/k3/v3/'
+        delim            = '/'
+        text_dict        = {'key1/':'value1','k2':'v2','k3':'v3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_delim_in_value_4(self):
+        """
+        Test that delimiter in keyword value still parses correctly.
+        
+        """
+        raw_text_segment = '/k1/v1///key2/value2/k3/v3/'
+        delim            = '/'
+        text_dict        = {'k1':'v1/','key2':'value2','k3':'v3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_delim_in_value_4_s(self):
+        """
+        Test that delimiter in keyword value still parses correctly.
+        
+        """
+        raw_text_segment = 'k1/v1///key2/value2/k3/v3/'
+        delim            = '/'
+        text_dict        = {'k1':'v1/','key2':'value2','k3':'v3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_delim_in_keyword_5(self):
+        """
+        Test that delimiter in keyword still parses correctly.
+        
+        """
+        raw_text_segment = '/k1/v1/key2///value2/k3/v3/'
+        delim            = '/'
+        text_dict        = {'k1':'v1','key2/':'value2','k3':'v3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_delim_in_keyword_5_s(self):
+        """
+        Test that delimiter in keyword still parses correctly.
+        
+        """
+        raw_text_segment = 'k1/v1/key2///value2/k3/v3/'
+        delim            = '/'
+        text_dict        = {'k1':'v1','key2/':'value2','k3':'v3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_delim_in_value_5(self):
+        """
+        Test that delimiter in keyword value still parses correctly.
+        
+        """
+        raw_text_segment = '/k1/v1/k2/v2///key3/value3/'
+        delim            = '/'
+        text_dict        = {'k1':'v1','k2':'v2/','key3':'value3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_delim_in_value_5_s(self):
+        """
+        Test that delimiter in keyword value still parses correctly.
+        
+        """
+        raw_text_segment = 'k1/v1/k2/v2///key3/value3/'
+        delim            = '/'
+        text_dict        = {'k1':'v1','k2':'v2/','key3':'value3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_delim_in_keyword_6(self):
+        """
+        Test that delimiter in keyword still parses correctly.
+        
+        """
+        raw_text_segment = '/k1/v1/k2/v2/key3///value3/'
+        delim            = '/'
+        text_dict        = {'k1':'v1','k2':'v2','key3/':'value3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_delim_in_keyword_6_s(self):
+        """
+        Test that delimiter in keyword still parses correctly.
+        
+        """
+        raw_text_segment = 'k1/v1/k2/v2/key3///value3/'
+        delim            = '/'
+        text_dict        = {'k1':'v1','k2':'v2','key3/':'value3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_delim_in_value_6(self):
+        """
+        Test that delimiter in keyword value still parses correctly.
+        
+        """
+        raw_text_segment = '/k1/v1/k2/v2/k3/v3///'
+        delim            = '/'
+        text_dict        = {'k1':'v1','k2':'v2','k3':'v3/'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_delim_in_value_6_s(self):
+        """
+        Test that delimiter in keyword value still parses correctly.
+        
+        """
+        raw_text_segment = 'k1/v1/k2/v2/k3/v3///'
+        delim            = '/'
+        text_dict        = {'k1':'v1','k2':'v2','k3':'v3/'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_bad_segment(self):
+        """
+        Test edge case with unpaired non-boundary delimiter in last value.
+        
+        """
+        raw_text_segment = '/k1/v1/k2/v2/k3/v3//'
+        delim            = '/'
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertRaises(
+            ValueError,
+            FlowCal.io.read_fcs_text_segment,
+            buf=buf, begin=0, end=len(raw_text_segment)-1, delim=delim,
+                supplemental=True)
+
+    def test_supp_bad_segment_s(self):
+        """
+        Test edge case with unpaired non-boundary delimiter in last value.
+        
+        """
+        raw_text_segment = 'k1/v1/k2/v2/k3/v3//'
+        delim            = '/'
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertRaises(
+            ValueError,
+            FlowCal.io.read_fcs_text_segment,
+            buf=buf, begin=0, end=len(raw_text_segment)-1, delim=delim,
+                supplemental=True)
+
+    def test_supp_multi_delim_in_keyword_1(self):
+        """
+        Test that multiple delimiters in keyword still parses correctly.
+        
+        """
+        raw_text_segment = '/k////1/v1/k2/v2/k3/v3/'
+        delim            = '/'
+        text_dict        = {'k//1':'v1','k2':'v2','k3':'v3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_multi_delim_in_keyword_1_s(self):
+        """
+        Test that multiple delimiters in keyword still parses correctly.
+        
+        """
+        raw_text_segment = 'k////1/v1/k2/v2/k3/v3/'
+        delim            = '/'
+        text_dict        = {'k//1':'v1','k2':'v2','k3':'v3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_multi_delim_in_value_1(self):
+        """
+        Test that multiple delimiters in keyword value still parses correctly.
+        
+        """
+        raw_text_segment = '/k1/v//1///k2/v2/k3/v3/'
+        delim            = '/'
+        text_dict        = {'k1':'v/1/','k2':'v2','k3':'v3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_multi_delim_in_value_1_s(self):
+        """
+        Test that multiple delimiters in keyword value still parses correctly.
+        
+        """
+        raw_text_segment = 'k1/v//1///k2/v2/k3/v3/'
+        delim            = '/'
+        text_dict        = {'k1':'v/1/','k2':'v2','k3':'v3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_multi_delim_in_keyword_2(self):
+        """
+        Test that multiple delimiters in keyword still parses correctly.
+        
+        """
+        raw_text_segment = '/k1/v1/k//2/////v2/k3/v3/'
+        delim            = '/'
+        text_dict        = {'k1':'v1','k/2//':'v2','k3':'v3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_multi_delim_in_keyword_2_s(self):
+        """
+        Test that multiple delimiters in keyword still parses correctly.
+        
+        """
+        raw_text_segment = 'k1/v1/k//2/////v2/k3/v3/'
+        delim            = '/'
+        text_dict        = {'k1':'v1','k/2//':'v2','k3':'v3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_multi_delim_in_value_2(self):
+        """
+        Test that multiple delimiters in keyword value still parses correctly.
+        
+        """
+        raw_text_segment = '/k1/v1/k2/v//////2/k3/v3/'
+        delim            = '/'
+        text_dict        = {'k1':'v1','k2':'v///2','k3':'v3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_multi_delim_in_value_2_s(self):
+        """
+        Test that multiple delimiters in keyword value still parses correctly.
+        
+        """
+        raw_text_segment = 'k1/v1/k2/v//////2/k3/v3/'
+        delim            = '/'
+        text_dict        = {'k1':'v1','k2':'v///2','k3':'v3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_multi_delim_in_keyword_3(self):
+        """
+        Test that multiple delimiters in keyword still parses correctly.
+        
+        """
+        raw_text_segment = '/k1/v1/k2/v2/k////3/v3/'
+        delim            = '/'
+        text_dict        = {'k1':'v1','k2':'v2','k//3':'v3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_multi_delim_in_keyword_3_s(self):
+        """
+        Test that multiple delimiters in keyword still parses correctly.
+        
+        """
+        raw_text_segment = 'k1/v1/k2/v2/k////3/v3/'
+        delim            = '/'
+        text_dict        = {'k1':'v1','k2':'v2','k//3':'v3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_multi_delim_in_value_3(self):
+        """
+        Test that multiple delimiters in keyword value still parses correctly.
+        
+        """
+        raw_text_segment = '/k1/v1/k2/v2/k3/v////3/'
+        delim            = '/'
+        text_dict        = {'k1':'v1','k2':'v2','k3':'v//3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_multi_delim_in_value_3_s(self):
+        """
+        Test that multiple delimiters in keyword value still parses correctly.
+        
+        """
+        raw_text_segment = 'k1/v1/k2/v2/k3/v////3/'
+        delim            = '/'
+        text_dict        = {'k1':'v1','k2':'v2','k3':'v//3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_multi_delim_in_value_4(self):
+        """
+        Test that multiple delimiters in keyword value still parses correctly.
+        
+        """
+        raw_text_segment = '/k1/v1/k2/v2/k3/v3/////'
+        delim            = '/'
+        text_dict        = {'k1':'v1','k2':'v2','k3':'v3//'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_multi_delim_in_value_4_s(self):
+        """
+        Test that multiple delimiters in keyword value still parses correctly.
+        
+        """
+        raw_text_segment = 'k1/v1/k2/v2/k3/v3/////'
+        delim            = '/'
+        text_dict        = {'k1':'v1','k2':'v2','k3':'v3//'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
+
+    def test_supp_multi_delim_in_keyword_fail(self):
+        """
+        Test that multiple delimiters at start of first keyword fails.
+        
+        """
+        raw_text_segment = '/////k1/v1/k2/v2/k3/v3/'
+        delim            = '/'
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertRaises(
+            ValueError,
+            FlowCal.io.read_fcs_text_segment,
+            buf=buf, begin=0, end=len(raw_text_segment)-1, delim=delim,
+                supplemental=True)
+
+    def test_supp_multi_delim_in_keyword_fail_s(self):
+        """
+        Test that multiple delimiters at start of first keyword fails.
+        
+        """
+        raw_text_segment = '////k1/v1/k2/v2/k3/v3/'
+        delim            = '/'
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertRaises(
+            ValueError,
+            FlowCal.io.read_fcs_text_segment,
+            buf=buf, begin=0, end=len(raw_text_segment)-1, delim=delim,
+                supplemental=True)
 
 class TestFCSParseTimeString(unittest.TestCase):
     def test_parse_none(self):

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -394,11 +394,14 @@ class TestReadTextSegment(unittest.TestCase):
         """
         raw_text_segment = '/k1/v1/k2/v2/k3/v3//'
         delim            = '/'
+        text_dict        = {'k1':'v1','k2':'v2','k3':'v3'}
         buf              = StringIO.StringIO(raw_text_segment)
-        self.assertRaises(
-            ValueError,
-            FlowCal.io.read_fcs_text_segment,
-            buf=buf, begin=0, end=len(raw_text_segment)-1, delim=delim)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1),
+            (text_dict, delim))
 
     def test_primary_multi_delim_in_keyword_1(self):
         """
@@ -1124,12 +1127,16 @@ class TestReadTextSegment(unittest.TestCase):
         """
         raw_text_segment = '/k1/v1/k2/v2/k3/v3//'
         delim            = '/'
+        text_dict        = {'k1':'v1','k2':'v2','k3':'v3'}
         buf              = StringIO.StringIO(raw_text_segment)
-        self.assertRaises(
-            ValueError,
-            FlowCal.io.read_fcs_text_segment,
-            buf=buf, begin=0, end=len(raw_text_segment)-1, delim=delim,
-                supplemental=True)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
 
     def test_supp_bad_segment_s(self):
         """
@@ -1138,12 +1145,16 @@ class TestReadTextSegment(unittest.TestCase):
         """
         raw_text_segment = 'k1/v1/k2/v2/k3/v3//'
         delim            = '/'
+        text_dict        = {'k1':'v1','k2':'v2','k3':'v3'}
         buf              = StringIO.StringIO(raw_text_segment)
-        self.assertRaises(
-            ValueError,
-            FlowCal.io.read_fcs_text_segment,
-            buf=buf, begin=0, end=len(raw_text_segment)-1, delim=delim,
-                supplemental=True)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1,
+                delim=delim,
+                supplemental=True),
+            (text_dict, delim))
 
     def test_supp_multi_delim_in_keyword_1(self):
         """

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -166,7 +166,7 @@ class TestReadTextSegment(unittest.TestCase):
                 end=len(raw_text_segment)-1),
             (text_dict, delim))
 
-    def test_primary_delim_fail_1(self):
+    def test_primary_delim_mismatch(self):
         """
         Test that primary TEXT segment delimiter mismatch fails.
 
@@ -182,75 +182,39 @@ class TestReadTextSegment(unittest.TestCase):
             FlowCal.io.read_fcs_text_segment,
             buf=buf, begin=0, end=len(raw_text_segment)-1, delim=delim)
 
-    def test_primary_delim_fail_2(self):
+    def test_primary_delim_in_keyword_1(self):
         """
-        Test that primary segment fails if delim is not first character.
-
-        This test fails because 'k' is deduced to be the delimiter, but upon
-        splitting on 'k', there are not an even number of pairs remaining.
+        Test that delimiter in keyword still parses correctly.
         
         """
-        raw_text_segment = 'k1/v1/'
+        raw_text_segment = '/key//1/value1/k2/v2/k3/v3/'
         delim            = '/'
+        text_dict        = {'key/1':'value1','k2':'v2','k3':'v3'}
         buf              = StringIO.StringIO(raw_text_segment)
-        self.assertRaises(
-            ValueError,
-            FlowCal.io.read_fcs_text_segment,
-            buf=buf, begin=0, end=len(raw_text_segment)-1)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1),
+            (text_dict, delim))
 
-    def test_primary_delim_fail_3(self):
+    def test_primary_delim_in_value_1(self):
         """
-        Test that primary segment fails if delim is not first character.
-
-        This test fails because, upon specifying the correct delimiter ('/'),
-        the delimiter does not match the first character of the primary TEXT
-        segment. Note, this same test should succeed for a supplemental TEXT
-        segment.
-
-        """
-        raw_text_segment = 'k1/v1/'
-        delim            = '/'
-        buf              = StringIO.StringIO(raw_text_segment)
-        self.assertRaises(
-            ValueError,
-            FlowCal.io.read_fcs_text_segment,
-            buf=buf, begin=0, end=len(raw_text_segment)-1, delim=delim)
-
-    def test_primary_bad_segment_1(self):
-        """
-        Test that read_fcs_text_segment() fails to parse minimal TEXT segment.
-
-        Test that read_fcs_text_segment() fails to parse a minimal TEXT
-        segment because it's either classified as having empty keywords and
-        values (which is prohibited by the standards), or it is perceived as
-        having keywords or values that start with the delimiter (also
-        prohibited by the standards).
-        """
-        raw_text_segment = '///'
-        delim            = '/'
-        buf              = StringIO.StringIO(raw_text_segment)
-        self.assertRaises(
-            ValueError,
-            FlowCal.io.read_fcs_text_segment,
-            buf=buf, begin=0, end=len(raw_text_segment)-1, delim=delim)
-
-    def test_primary_bad_segment_2(self):
-        """
-        Test that read_fcs_text_segment() fails to parse minimal TEXT segment.
-
-        This test fails to parse because there is no keyword, only a value
-        flanked by delimiters.
+        Test that delimiter in keyword value still parses correctly.
         
         """
-        raw_text_segment = '/str/ing'
+        raw_text_segment = '/key1/value//1/k2/v2/k3/v3/'
         delim            = '/'
+        text_dict        = {'key1':'value/1','k2':'v2','k3':'v3'}
         buf              = StringIO.StringIO(raw_text_segment)
-        self.assertRaises(
-            ValueError,
-            FlowCal.io.read_fcs_text_segment,
-            buf=buf, begin=0, end=len(raw_text_segment)-1, delim=delim)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1),
+            (text_dict, delim))
 
-    def test_primary_delim_in_keyword(self):
+    def test_primary_delim_in_keyword_2(self):
         """
         Test that delimiter in keyword still parses correctly.
         
@@ -266,7 +230,7 @@ class TestReadTextSegment(unittest.TestCase):
                 end=len(raw_text_segment)-1),
             (text_dict, delim))
 
-    def test_primary_delim_in_value(self):
+    def test_primary_delim_in_value_2(self):
         """
         Test that delimiter in keyword value still parses correctly.
         
@@ -282,40 +246,14 @@ class TestReadTextSegment(unittest.TestCase):
                 end=len(raw_text_segment)-1),
             (text_dict, delim))
 
-    def test_primary_delim_in_keyword_fail(self):
-        """
-        Test that delimiter at start of keyword fails.
-        
-        """
-        raw_text_segment = '/k1/v1///key2/value2/k3/v3/'
-        delim            = '/'
-        buf              = StringIO.StringIO(raw_text_segment)
-        self.assertRaises(
-            ValueError,
-            FlowCal.io.read_fcs_text_segment,
-            buf=buf, begin=0, end=len(raw_text_segment)-1, delim=delim)
-
-    def test_primary_delim_in_value_fail(self):
-        """
-        Test that delimiter at start of keyword value fails.
-        
-        """
-        raw_text_segment = '/k1/v1/key2///value2/k3/v3/'
-        delim            = '/'
-        buf              = StringIO.StringIO(raw_text_segment)
-        self.assertRaises(
-            ValueError,
-            FlowCal.io.read_fcs_text_segment,
-            buf=buf, begin=0, end=len(raw_text_segment)-1, delim=delim)
-
-    def test_primary_multi_delim_in_keyword(self):
+    def test_primary_delim_in_keyword_3(self):
         """
         Test that delimiter in keyword still parses correctly.
         
         """
-        raw_text_segment = '/k1/v1/key//////2/value2/k3/v3/'
+        raw_text_segment = '/k1/v1/k2/v2/key//3/value3/'
         delim            = '/'
-        text_dict        = {'k1':'v1','key///2':'value2','k3':'v3'}
+        text_dict        = {'k1':'v1','k2':'v2','key/3':'value3'}
         buf              = StringIO.StringIO(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
@@ -323,7 +261,270 @@ class TestReadTextSegment(unittest.TestCase):
                 begin=0,
                 end=len(raw_text_segment)-1),
             (text_dict, delim))
-    
+
+    def test_primary_delim_in_value_3(self):
+        """
+        Test that delimiter in keyword value still parses correctly.
+        
+        """
+        raw_text_segment = '/k1/v1/k2/v2/key3/value//3/'
+        delim            = '/'
+        text_dict        = {'k1':'v1','k2':'v2','key3':'value/3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1),
+            (text_dict, delim))
+
+    def test_primary_first_keyword_delim_fail(self):
+        """
+        Test that delimiter at start of first keyword fails.
+        
+        """
+        raw_text_segment = '///key1/value1/k2/v2/k3/v3/'
+        delim            = '/'
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertRaises(
+            ValueError,
+            FlowCal.io.read_fcs_text_segment,
+            buf=buf, begin=0, end=len(raw_text_segment)-1, delim=delim)
+
+    def test_primary_delim_in_keyword_4(self):
+        """
+        Test that delimiter in keyword still parses correctly.
+        
+        """
+        raw_text_segment = '/key1///value1/k2/v2/k3/v3/'
+        delim            = '/'
+        text_dict        = {'key1/':'value1','k2':'v2','k3':'v3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1),
+            (text_dict, delim))
+
+    def test_primary_delim_in_value_4(self):
+        """
+        Test that delimiter in keyword value still parses correctly.
+        
+        """
+        raw_text_segment = '/k1/v1///key2/value2/k3/v3/'
+        delim            = '/'
+        text_dict        = {'k1':'v1/','key2':'value2','k3':'v3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1),
+            (text_dict, delim))
+
+    def test_primary_delim_in_keyword_5(self):
+        """
+        Test that delimiter in keyword still parses correctly.
+        
+        """
+        raw_text_segment = '/k1/v1/key2///value2/k3/v3/'
+        delim            = '/'
+        text_dict        = {'k1':'v1','key2/':'value2','k3':'v3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1),
+            (text_dict, delim))
+
+    def test_primary_delim_in_value_5(self):
+        """
+        Test that delimiter in keyword value still parses correctly.
+        
+        """
+        raw_text_segment = '/k1/v1/k2/v2///key3/value3/'
+        delim            = '/'
+        text_dict        = {'k1':'v1','k2':'v2/','key3':'value3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1),
+            (text_dict, delim))
+
+    def test_primary_delim_in_keyword_6(self):
+        """
+        Test that delimiter in keyword still parses correctly.
+        
+        """
+        raw_text_segment = '/k1/v1/k2/v2/key3///value3/'
+        delim            = '/'
+        text_dict        = {'k1':'v1','k2':'v2','key3/':'value3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1),
+            (text_dict, delim))
+
+    def test_primary_delim_in_value_6(self):
+        """
+        Test that delimiter in keyword value still parses correctly.
+        
+        """
+        raw_text_segment = '/k1/v1/k2/v2/k3/v3///'
+        delim            = '/'
+        text_dict        = {'k1':'v1','k2':'v2','k3':'v3/'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1),
+            (text_dict, delim))
+
+    def test_primary_bad_segment(self):
+        """
+        Test edge case with unpaired non-boundary delimiter in last value.
+        
+        """
+        raw_text_segment = '/k1/v1/k2/v2/k3/v3//'
+        delim            = '/'
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertRaises(
+            ValueError,
+            FlowCal.io.read_fcs_text_segment,
+            buf=buf, begin=0, end=len(raw_text_segment)-1, delim=delim)
+
+    def test_primary_multi_delim_in_keyword_1(self):
+        """
+        Test that multiple delimiters in keyword still parses correctly.
+        
+        """
+        raw_text_segment = '/k////1/v1/k2/v2/k3/v3/'
+        delim            = '/'
+        text_dict        = {'k//1':'v1','k2':'v2','k3':'v3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1),
+            (text_dict, delim))
+
+    def test_primary_multi_delim_in_value_1(self):
+        """
+        Test that multiple delimiters in keyword value still parses correctly.
+        
+        """
+        raw_text_segment = '/k1/v//1///k2/v2/k3/v3/'
+        delim            = '/'
+        text_dict        = {'k1':'v/1/','k2':'v2','k3':'v3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1),
+            (text_dict, delim))
+
+    def test_primary_multi_delim_in_keyword_2(self):
+        """
+        Test that multiple delimiters in keyword still parses correctly.
+        
+        """
+        raw_text_segment = '/k1/v1/k//2/////v2/k3/v3/'
+        delim            = '/'
+        text_dict        = {'k1':'v1','k/2//':'v2','k3':'v3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1),
+            (text_dict, delim))
+
+    def test_primary_multi_delim_in_value_2(self):
+        """
+        Test that multiple delimiters in keyword value still parses correctly.
+        
+        """
+        raw_text_segment = '/k1/v1/k2/v//////2/k3/v3/'
+        delim            = '/'
+        text_dict        = {'k1':'v1','k2':'v///2','k3':'v3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1),
+            (text_dict, delim))
+
+    def test_primary_multi_delim_in_keyword_3(self):
+        """
+        Test that multiple delimiters in keyword still parses correctly.
+        
+        """
+        raw_text_segment = '/k1/v1/k2/v2/k////3/v3/'
+        delim            = '/'
+        text_dict        = {'k1':'v1','k2':'v2','k//3':'v3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1),
+            (text_dict, delim))
+
+    def test_primary_multi_delim_in_value_3(self):
+        """
+        Test that multiple delimiters in keyword value still parses correctly.
+        
+        """
+        raw_text_segment = '/k1/v1/k2/v2/k3/v////3/'
+        delim            = '/'
+        text_dict        = {'k1':'v1','k2':'v2','k3':'v//3'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1),
+            (text_dict, delim))
+
+    def test_primary_multi_delim_in_value_4(self):
+        """
+        Test that multiple delimiters in keyword value still parses correctly.
+        
+        """
+        raw_text_segment = '/k1/v1/k2/v2/k3/v3/////'
+        delim            = '/'
+        text_dict        = {'k1':'v1','k2':'v2','k3':'v3//'}
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertEqual(
+            FlowCal.io.read_fcs_text_segment(
+                buf=buf,
+                begin=0,
+                end=len(raw_text_segment)-1),
+            (text_dict, delim))
+
+    def test_primary_multi_delim_in_keyword_fail(self):
+        """
+        Test that multiple delimiters at start of first keyword fails.
+        
+        """
+        raw_text_segment = '/////k1/v1/k2/v2/k3/v3/'
+        delim            = '/'
+        buf              = StringIO.StringIO(raw_text_segment)
+        self.assertRaises(
+            ValueError,
+            FlowCal.io.read_fcs_text_segment,
+            buf=buf, begin=0, end=len(raw_text_segment)-1, delim=delim)
+   
     ###
     # Supplemental TEXT Segment Tests
     ###


### PR DESCRIPTION
## Summary
- Fixes #247 (supplemental TEXT segments are no longer required to start with delimiter).
- Also fixes related bug which arises when a TEXT segment delimiter character occurs in a TEXT segment keyword or keyword value.
- Test FCS files which were previously parsed without error now fail to parse, possibly necessitating a new, more flexible/lenient approach to parsing FCS files?
## Changes to Keyword/Value Delimiter Reconstruction Algorithm
[Old Implementation](https://github.com/taborlab/FlowCal/blob/4420e15428d13923e8da32f85ae7676adfeade81/FlowCal/io.py#L186) (`develop`, 4420e15428d13923e8da32f85ae7676adfeade81): a sequence of consecutive delimiter characters must be escaped once (as opposed to escaping each delimiter character individually).
- e.g. - the Python dictionary `{'key///1':'value1'}` maps to the following primary TEXT segment: `'/key////1/value1/'`

[New Implementation](https://github.com/taborlab/FlowCal/blob/6fcce1c24adadc2110ab782f9063f6649a7c3dbd/FlowCal/io.py#L212) (6fcce1c24adadc2110ab782f9063f6649a7c3dbd): each instance of a delimiter character that exists in a keyword or keyword value must be escaped individually.
- e.g. - the Python dictionary `{'key///1':'value1'}` maps to the following primary TEXT segment: `'/key//////1/value1/'`

The FCS standards are frustratingly unclear on this distinction. I spoke with @castillohair, though, and we both agree that the New Implementation is more appropriate.

Note: the issue of delimiter characters in keywords or keyword values was first addressed in #203 and #206.

## Validation
To validate these bug fixes, I wrote [77 unit tests](https://github.com/taborlab/FlowCal/blob/6fcce1c24adadc2110ab782f9063f6649a7c3dbd/test/test_io.py#L108).
- The primary TEXT segment tests run against `develop` (4420e15428d13923e8da32f85ae7676adfeade81) (26 tests total) result in: `FAILED (failures=9, errors=7)`
- The primary and supplemental TEXT segment tests (77 tests total) all pass against 6fcce1c24adadc2110ab782f9063f6649a7c3dbd.

In addition to unit tests, I also wrote a script which attempts to load FCS files from the following FCS file repository: https://flowrepository.org/id/FR-FCM-ZZZ4. I also included some possible troublemaker files from a flow cytometry interlab study currently under way (`N007.fcs`, `N009.fcs`, `N016.fcs`, `N022.fcs`).

Script (`io_test.py`, cannibalized from #203 script):
```python
import FlowCal as fc
import os
import numpy as np

flow_dir = 'fcs_files'

files = os.listdir(flow_dir)

for idx,filename in enumerate(files):
    print('\n{0:02d} : {1:}'.format(idx,filename))
    try:
        f = fc.io.FCSFile(os.path.join(flow_dir,filename))

        # Version
        print('-version:\t\t\t\t\t{}'.format(f.header.version))

        # Number of channels and datatype
        num_chan = int(f.text['$PAR'])
        print('-num channels ($PAR):\t\t{}'.format(num_chan))
        print('-$DATATYPE:\t\t\t\t\t{}'.format(f.text['$DATATYPE']))

        # Look at bit widths
        param_bit_widths = [int(f.text['$P{0}B'.format(p)])
                            for p in xrange(1,num_chan+1)]
        unique_bw = np.unique(param_bit_widths)
        print('-unique bit widths ($PnB):\t({})'.format(','.join(str(u) for u in unique_bw)))

        # Supplemental TEXT segment
        stext_begin = f.text.get('$BEGINSTEXT')
        stext_end = f.text.get('$ENDSTEXT')
        print('-supplemental TEXT?:\t\t($BEGINSTEXT={},$ENDSTEXT={})'.format(stext_begin, stext_end))

        # ANALYSIS segment
        print('-ANALYSIS segment?:\t\t\t{}'.format(len(f.analysis)>0))

    except Exception as e:
        print('E:{}'.format(e))
```

Diff of script outputs run under `develop` (4420e15428d13923e8da32f85ae7676adfeade81) and 6fcce1c24adadc2110ab782f9063f6649a7c3dbd:

![6fcce1c_4420e15_diff](https://cloud.githubusercontent.com/assets/2179825/25735329/317b6670-3130-11e7-935e-22d731fa6569.png)

### Analysis
Summary of diff results: three different Accuri files (`02`, `03`, `04`) now fail to parse, the Applied Biosystems file (`06`) fails with a different error message, and the problematic interlab study file (`N016.fcs`) (which ultimately brought this issue to light) is now parsed where it previously threw an error.

Taking a closer look at the 3 Accuri files that fail, they all seem to end their primary TEXT segments in a prohibited fashion:
 - `02` primary TEXT segment ending: `'.../#P14MaxUsefulDataChannel/1279//'`
 - `03` primary TEXT segment ending: `'.../#P14MaxUsefulDataChannel/1567//'`
 - `04` primary TEXT segment ending: `'.../#P14MaxUsefulDataChannel/4319//'`

Note the double `/` at the end (which happens to be tested in [this unit test](https://github.com/taborlab/FlowCal/blob/6fcce1c24adadc2110ab782f9063f6649a7c3dbd/test/test_io.py#L390)). According to the FCS standards:
> Since null (zero length) keywords or keyword values are not permitted, two consecutive delimiters can never occur between a value and a keyword.

Furthermore, the 4th Accuri file does *not* suffer the double `/` character terminating its primary TEXT segment and is parsed successfully:
- `05` primary TEXT segment ending: `'.../$ENDANALYSIS/0/#SPACERS/000/'`

The Applied Biosystems file (`06`) appears to have empty values in its primary TEXT segment, which is prohibited. This TEXT segment could almost still be parsed incorrectly (joining keywords with a delimiter character when the value is empty) if it weren't for the fact that the *last* value is empty (I didn't count all of the keyword-value pairs, so it's possible that it would still fail due to an odd number of keyword-value pairs after keywords with empty values were erroneously join via delimiters).

According to my best interpretation of a strict reading of the FCS standards, the file behaviors described above are correct and these bug fixes are consistent with the standards.

## Proposal: Warnings for Recoverable Parsing Failures?

While being technically correct is nice, it can sometimes be unnecessarily limiting. In the context of this bug fix, it may very well be possible to recover an ill-formed TEXT segment if some of the FCS standard constraints are relaxed. If such flexibility is embraced, I think the `FCSFile` object should throw a `warning` when it is forced to recover from a parsing failure. I'm not sure what form such flexibility would take in practice, though (multiple `read_fcs_text_segment()` functions? A single, more sophisticated `read_fcs_text_segment()` which makes multiple passes on ill-formed TEXT segments?), and supporting these edge cases may require a significant amount of programming effort which may not be justified given current usage patterns.

I will say that I think this approach of raising warnings upon deviation from the FCS standards would also be useful for other segment parsing functions (e.g. `read_fcs_data_segment()` with those Accuri files again, which necessitated [this hack](https://github.com/taborlab/FlowCal/pull/206/commits/c5f1b9a5404d9578daf3a8f20dfe55ed93710115)).