### PR TITLE
More explicit error message in Excel UI.

### DIFF
--- a/FlowCal/excel_ui.py
+++ b/FlowCal/excel_ui.py
@@ -480,7 +480,8 @@ def process_beads_table(beads_table,
                     raise ExcelUIException("Must specify the same number of"
                                            + " MEF Values for each channel."
                                            + " Use 'None' to instruct FlowCal"
-                                           + " to ignore a detected peak.")
+                                           + " to ignore a detected"
+                                           + " subpopulation.")
             mef_values = np.array(mef_values)
 
             # Obtain standard curve transformation

--- a/FlowCal/excel_ui.py
+++ b/FlowCal/excel_ui.py
@@ -470,6 +470,17 @@ def process_beads_table(beads_table,
                     mef = [int(e) if e.strip().isdigit() else np.nan
                            for e in mef]
                     mef_values.append(mef)
+
+            # Ensure matching number of `mef_values` for all channels (this
+            # implies that the calibration beads have the same number of
+            # subpopulations for all channels).
+            if mef_values:
+                if not np.all([len(mef_values_channel)==len(mef_values[0])
+                               for mef_values_channel in mef_values]):
+                    raise ExcelUIException("Must specify the same number of"
+                                           + " MEF Values for each channel."
+                                           + " Use 'None' to instruct FlowCal"
+                                           + " to ignore a detected peak.")
             mef_values = np.array(mef_values)
 
             # Obtain standard curve transformation

--- a/FlowCal/mef.py
+++ b/FlowCal/mef.py
@@ -537,9 +537,11 @@ def get_transform_fxn(data_beads,
     ----------
     data_beads : FCSData object
         Flow cytometry data, taken from calibration beads.
-    mef_values : array
-        Known MEF values of the calibration beads' subpopulations, for
-        each channel specified in `mef_channels`.
+    mef_values : sequence of sequences
+        Known MEF values for the calibration bead subpopulations, for each
+        channel specified in `mef_channels`. The innermost sequences must have
+        the same length (the same number of bead subpopulations must exist for
+        each channel).
     mef_channels : int, or str, or list of int, or list of str
         Channels for which to generate transformation functions.
     verbose : bool, optional
@@ -727,10 +729,16 @@ def get_transform_fxn(data_beads,
     # mef_channels and mef_values should be iterables.
     if hasattr(mef_channels, '__iter__'):
         mef_channels = list(mef_channels)
-        mef_values = np.array(mef_values).copy()
     else:
         mef_channels = [mef_channels]
-        mef_values = np.array([mef_values]).copy()
+        mef_values   = [mef_values]
+
+    # Ensure matching number of `mef_values` for all channels (this implies
+    # that the calibration beads have the same number of subpopulations for
+    # all channels).
+    if not np.all([len(mef_values_channel)==len(mef_values[0])
+                   for mef_values_channel in mef_values]):
+        raise ValueError("mef_values must be same length for all channels")
 
     ###
     # 1. Clustering
@@ -741,7 +749,7 @@ def get_transform_fxn(data_beads,
         clustering_channels = mef_channels
 
     # Get number of clusters from number of specified MEF values
-    n_clusters = mef_values.shape[1]
+    n_clusters = len(mef_values[0])
 
     # Run clustering function
     labels = clustering_fxn(data_beads[:, clustering_channels],

--- a/FlowCal/mef.py
+++ b/FlowCal/mef.py
@@ -738,7 +738,10 @@ def get_transform_fxn(data_beads,
     # all channels).
     if not np.all([len(mef_values_channel)==len(mef_values[0])
                    for mef_values_channel in mef_values]):
-        raise ValueError("mef_values must be same length for all channels")
+        msg  = "innermost sequences of mef_values must have the same length"
+        msg += " (same number of bead subpopulations must exist for each"
+        msg += " channel)"
+        raise ValueError(msg)
 
     ###
     # 1. Clustering


### PR DESCRIPTION
Added more explicit error message if the user doesn't specify the same number of MEF Values for all channels of a bead entry in the Beads tab of the Excel UI.

See #239.