### PR TITLE
Pandas compatibility fix

### DIFF
--- a/FlowCal/excel_ui.py
+++ b/FlowCal/excel_ui.py
@@ -171,10 +171,10 @@ def write_workbook(filename, table_list, column_width=None):
     # Modify default header format
     # Pandas' default header format is bold text with thin borders. Here we
     # use bold text only, without borders.
-    # The format module is in pd.core.format in pandas<=0.18.0,
-    # pd.formats.format in pandas>=0.18.1, and pd.io.formats.excel in
+    # The header style structure is in pd.core.format in pandas<=0.18.0,
+    # pd.formats.format in 0.18.1<=pandas<0.20, and pd.io.formats.excel in
     # pandas>=0.20.
-    # Also, wrap in a try-except block in case format module is not found.
+    # Also, wrap in a try-except block in case style structure is not found.
     format_module_found = False
     try:
         # Get format module

--- a/doc/getting_started/install_python.rst
+++ b/doc/getting_started/install_python.rst
@@ -14,6 +14,7 @@ Alternatively, download ``FlowCal`` from `here <https://github.com/taborlab/Flow
 * ``matplotlib`` (>=1.3.1)
 * ``palettable`` (>=2.1.1)
 * ``scikit-learn`` (>=0.16.0)
+* ``packaging`` (>=16.8)
 * ``pandas`` (>=0.16.1)
 * ``xlrd`` (>=0.9.2)
 * ``XlsxWriter`` (>=0.5.2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ scipy>=0.14.0
 matplotlib>=1.3.1
 palettable>=2.1.1
 scikit-learn>=0.16.0
+packaging>=16.8
 pandas>=0.16.1
 xlrd>=0.9.2
 XlsxWriter>=0.5.2

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ setup(
                       'matplotlib>=1.3.1',
                       'palettable>=2.1.1',
                       'scikit-learn>=0.16.0',
+                      'packaging>=16.8',
                       'pandas>=0.16.1',
                       'xlrd>=0.9.2',
                       'XlsxWriter>=0.5.2'],


### PR DESCRIPTION
Fixes #257. Adds the requirement for the `packaging` module, which is, as far as I've found, the best way to compare module versions. This will be useful later when fixing #230.

I intend the solution of this and #258 to be part of a hotfix, to be pushed ASAP.