### PR TITLE
Python3 Support

### DIFF
--- a/FlowCal/__init__.py
+++ b/FlowCal/__init__.py
@@ -8,10 +8,10 @@
 # https://packaging.python.org/en/latest/single_source_version.html
 __version__ = '1.1.4'
 
-import io
-import excel_ui
-import gate
-import transform
-import mef
-import plot
-import stats
+from . import io
+from . import excel_ui
+from . import gate
+from . import transform
+from . import mef
+from . import plot
+from . import stats

--- a/FlowCal/excel_ui.py
+++ b/FlowCal/excel_ui.py
@@ -77,10 +77,18 @@ import packaging.version
 import platform
 import re
 import subprocess
+import sys
 import time
-from Tkinter import Tk
-from tkFileDialog import askopenfilename
 import warnings
+
+# Tkinter is imported differently depending on which version of python we're
+# using.
+if sys.version_info.major == 2:
+    from Tkinter import Tk
+    from tkFileDialog import askopenfilename
+elif sys.version_info.major == 3:
+    from tkinter import Tk
+    from tkinter.filedialog import askopenfilename
 
 from matplotlib import pyplot as plt
 import numpy as np
@@ -133,7 +141,8 @@ def read_table(filename, sheetname, index_col=None):
 
     """
     # Catch sheetname as list or None
-    if sheetname is None or hasattr(sheetname, '__iter__'):
+    if sheetname is None or \
+        (hasattr(sheetname, '__iter__') and not isinstance(sheetname, str)):
         raise TypeError("sheetname should specify a single sheet")
 
     # Load excel table using pandas
@@ -205,7 +214,7 @@ def write_workbook(filename, table_list, column_width=None):
         df.to_excel(writer, sheet_name=sheet_name, index=False)
         # Set column width
         if column_width is None:
-            for i, (col_name, column) in enumerate(df.iteritems()):
+            for i, (col_name, column) in enumerate(iter(df.items())):
                 # Get the maximum number of characters in a column
                 max_chars_col = column.astype(str).str.len().max()
                 max_chars_col = max(len(col_name), max_chars_col)
@@ -1287,7 +1296,7 @@ def generate_about_table(extra_info={}):
     keywords.append('Time of analysis')
     values.append(time.strftime("%I:%M:%S%p"))
     # Add additional keyword:value pairs
-    for k, v in extra_info.items():
+    for k, v in iter(extra_info.items()):
         keywords.append(k)
         values.append(v)
 

--- a/FlowCal/excel_ui.py
+++ b/FlowCal/excel_ui.py
@@ -76,6 +76,7 @@ import packaging
 import packaging.version
 import platform
 import re
+import six
 import subprocess
 import sys
 import time
@@ -142,7 +143,8 @@ def read_table(filename, sheetname, index_col=None):
     """
     # Catch sheetname as list or None
     if sheetname is None or \
-        (hasattr(sheetname, '__iter__') and not isinstance(sheetname, str)):
+            (hasattr(sheetname, '__iter__') \
+            and not isinstance(sheetname, six.string_types)):
         raise TypeError("sheetname should specify a single sheet")
 
     # Load excel table using pandas

--- a/FlowCal/excel_ui.py
+++ b/FlowCal/excel_ui.py
@@ -78,16 +78,17 @@ import platform
 import re
 import six
 import subprocess
-import sys
 import time
 import warnings
 
 # Tkinter is imported differently depending on which version of python we're
 # using.
-if sys.version_info.major == 2:
+# six.PY2 is True when the code is running in python 2, False otherwise.
+# six.PY3 is the equivalent for python 3.
+if six.PY2:
     from Tkinter import Tk
     from tkFileDialog import askopenfilename
-elif sys.version_info.major == 3:
+elif six.PY3:
     from tkinter import Tk
     from tkinter.filedialog import askopenfilename
 

--- a/FlowCal/excel_ui.py
+++ b/FlowCal/excel_ui.py
@@ -217,7 +217,7 @@ def write_workbook(filename, table_list, column_width=None):
         df.to_excel(writer, sheet_name=sheet_name, index=False)
         # Set column width
         if column_width is None:
-            for i, (col_name, column) in enumerate(iter(df.items())):
+            for i, (col_name, column) in enumerate(six.iteritems(df)):
                 # Get the maximum number of characters in a column
                 max_chars_col = column.astype(str).str.len().max()
                 max_chars_col = max(len(col_name), max_chars_col)
@@ -1299,7 +1299,7 @@ def generate_about_table(extra_info={}):
     keywords.append('Time of analysis')
     values.append(time.strftime("%I:%M:%S%p"))
     # Add additional keyword:value pairs
-    for k, v in iter(extra_info.items()):
+    for k, v in six.iteritems(extra_info):
         keywords.append(k)
         values.append(v)
 

--- a/FlowCal/gate.py
+++ b/FlowCal/gate.py
@@ -520,8 +520,8 @@ def density2d(data,
         # just going to make sure the path codes aren't unfamiliar and then extract
         # all of the vertices and pack them into a list of 2D contours.
         cntr = []
-        num_cntrs = len(tr)/2
-        for idx in xrange(num_cntrs):
+        num_cntrs = len(tr)//2
+        for idx in range(num_cntrs):
             vertices = tr[idx]
             codes = tr[num_cntrs+idx]
 

--- a/FlowCal/io.py
+++ b/FlowCal/io.py
@@ -940,9 +940,9 @@ class FCSFile(object):
     def __hash__(self):
         return hash((self.infile,
                      self.header,
-                     frozenset(iter(self.text.items())),
+                     frozenset(six.iteritems(self.text)),
                      self.data.tobytes(),
-                     frozenset(iter(self.analysis.items()))))
+                     frozenset(six.iteritems(self.analysis))))
 
     def __repr__(self):
         return str(self.infile)

--- a/FlowCal/io.py
+++ b/FlowCal/io.py
@@ -8,7 +8,6 @@ import copy
 import collections
 import datetime
 import six
-import sys
 import warnings
 
 import numpy as np
@@ -80,16 +79,16 @@ def read_fcs_header_segment(buf, begin=0):
     field_values = []
 
     buf.seek(begin)
-    field_values.append(str(buf.read(10)).rstrip())     # version
+    field_values.append(buf.read(10).decode().rstrip()) # version
 
     field_values.append(int(buf.read(8)))               # text_begin
     field_values.append(int(buf.read(8)))               # text_end
     field_values.append(int(buf.read(8)))               # data_begin
     field_values.append(int(buf.read(8)))               # data_end
 
-    fv = buf.read(8)                                    # analysis_begin
+    fv = buf.read(8).decode()                           # analysis_begin
     field_values.append(0 if fv == ' '*8 else int(fv))
-    fv = buf.read(8)                                    # analysis_end
+    fv = buf.read(8).decode()                           # analysis_end
     field_values.append(0 if fv == ' '*8 else int(fv))
 
     header = FCSHeader._make(field_values)
@@ -174,7 +173,7 @@ def read_fcs_text_segment(buf, begin, end, delim=None, supplemental=False):
         else:
             buf.seek(begin)
             delim = buf.read(1)
-            if sys.version_info.major >= 3:
+            if six.PY3:
                 delim = chr(delim[0])
 
     # The offsets are inclusive (meaning they specify first and last byte
@@ -183,7 +182,7 @@ def read_fcs_text_segment(buf, begin, end, delim=None, supplemental=False):
     # ((end+1) - begin).
     buf.seek(begin)
     raw = buf.read((end+1)-begin)
-    if sys.version_info.major >= 3:
+    if six.PY3:
         raw = "".join(map(chr, raw))
 
     # If segment is empty, return empty dictionary as text

--- a/FlowCal/io.py
+++ b/FlowCal/io.py
@@ -14,6 +14,8 @@ import numpy as np
 
 import FlowCal.plot
 
+encoding = 'ISO-8859-1'
+
 ###
 # Utility functions for importing segments of FCS files
 ###
@@ -79,16 +81,16 @@ def read_fcs_header_segment(buf, begin=0):
     field_values = []
 
     buf.seek(begin)
-    field_values.append(buf.read(10).decode().rstrip()) # version
+    field_values.append(buf.read(10).decode(encoding).rstrip()) # version
 
-    field_values.append(int(buf.read(8)))               # text_begin
-    field_values.append(int(buf.read(8)))               # text_end
-    field_values.append(int(buf.read(8)))               # data_begin
-    field_values.append(int(buf.read(8)))               # data_end
+    field_values.append(int(buf.read(8)))                       # text_begin
+    field_values.append(int(buf.read(8)))                       # text_end
+    field_values.append(int(buf.read(8)))                       # data_begin
+    field_values.append(int(buf.read(8)))                       # data_end
 
-    fv = buf.read(8).decode()                           # analysis_begin
+    fv = buf.read(8).decode(encoding)                           # analysis_begin
     field_values.append(0 if fv == ' '*8 else int(fv))
-    fv = buf.read(8).decode()                           # analysis_end
+    fv = buf.read(8).decode(encoding)                           # analysis_end
     field_values.append(0 if fv == ' '*8 else int(fv))
 
     header = FCSHeader._make(field_values)
@@ -172,18 +174,14 @@ def read_fcs_text_segment(buf, begin, end, delim=None, supplemental=False):
                              + " TEXT segment")
         else:
             buf.seek(begin)
-            delim = buf.read(1)
-            if six.PY3:
-                delim = chr(delim[0])
+            delim = buf.read(1).decode(encoding)
 
     # The offsets are inclusive (meaning they specify first and last byte
     # WITHIN segment) and seeking is inclusive (read() after seek() reads the
     # byte which was seeked to). This means the length of the segment is
     # ((end+1) - begin).
     buf.seek(begin)
-    raw = buf.read((end+1)-begin)
-    if six.PY3:
-        raw = "".join(map(chr, raw))
+    raw = buf.read((end+1)-begin).decode(encoding)
 
     # If segment is empty, return empty dictionary as text
     if not raw:

--- a/FlowCal/io.py
+++ b/FlowCal/io.py
@@ -7,6 +7,7 @@ import os
 import copy
 import collections
 import datetime
+import six
 import sys
 import warnings
 
@@ -735,7 +736,7 @@ class FCSFile(object):
         
         self._infile = infile
 
-        if isinstance(infile, str):
+        if isinstance(infile, six.string_types):
             f = open(infile, 'rb')
         else:
             f = infile
@@ -869,7 +870,7 @@ class FCSFile(object):
             raise ValueError("DATA segment incorrectly specified")
         self._data.flags.writeable = False
 
-        if isinstance(infile, str):
+        if isinstance(infile, six.string_types):
             f.close()
 
     # Expose attributes as read-only properties
@@ -1239,7 +1240,8 @@ class FCSData(np.ndarray):
         channels = self._name_to_index(channels)
 
         # Get detector type of the specified channels
-        if hasattr(channels, '__iter__') and not isinstance(channels, str):
+        if hasattr(channels, '__iter__') \
+                and not isinstance(channels, six.string_types):
             return [self._amplification_type[ch] for ch in channels]
         else:
             return self._amplification_type[channels]
@@ -1274,7 +1276,8 @@ class FCSData(np.ndarray):
         channels = self._name_to_index(channels)
 
         # Get detector type of the specified channels
-        if hasattr(channels, '__iter__') and not isinstance(channels, str):
+        if hasattr(channels, '__iter__') \
+                and not isinstance(channels, six.string_types):
             return [self._detector_voltage[ch] for ch in channels]
         else:
             return self._detector_voltage[channels]
@@ -1309,7 +1312,8 @@ class FCSData(np.ndarray):
         channels = self._name_to_index(channels)
 
         # Get detector type of the specified channels
-        if hasattr(channels, '__iter__') and not isinstance(channels, str):
+        if hasattr(channels, '__iter__') \
+                and not isinstance(channels, six.string_types):
             return [self._amplifier_gain[ch] for ch in channels]
         else:
             return self._amplifier_gain[channels]
@@ -1350,7 +1354,8 @@ class FCSData(np.ndarray):
         channels = self._name_to_index(channels)
 
         # Get the range of the specified channels
-        if hasattr(channels, '__iter__') and not isinstance(channels, str):
+        if hasattr(channels, '__iter__') \
+                and not isinstance(channels, six.string_types):
             return [self._range[ch] for ch in channels]
         else:
             return self._range[channels]
@@ -1384,7 +1389,8 @@ class FCSData(np.ndarray):
         channels = self._name_to_index(channels)
 
         # Get resolution of the specified channels
-        if hasattr(channels, '__iter__') and not isinstance(channels, str):
+        if hasattr(channels, '__iter__') \
+                and not isinstance(channels, six.string_types):
             return [self._resolution[ch] for ch in channels]
         else:
             return self._resolution[channels]
@@ -1893,10 +1899,11 @@ class FCSData(np.ndarray):
 
         """
         # Check if list, then run recursively
-        if hasattr(channels, '__iter__') and not isinstance(channels, str):
+        if hasattr(channels, '__iter__') \
+                and not isinstance(channels, six.string_types):
             return [self._name_to_index(ch) for ch in channels]
 
-        if isinstance(channels, str):
+        if isinstance(channels, six.string_types):
             # channels is a string containing a channel name
             if channels in self.channels:
                 return self.channels.index(channels)

--- a/FlowCal/mef.py
+++ b/FlowCal/mef.py
@@ -19,7 +19,7 @@ import FlowCal.stats
 # Use default colors from palettable if available
 try:
     import palettable
-except ImportError, e:
+except ImportError as e:
     standard_curve_colors = ['b', 'g', 'r']
 else:
     standard_curve_colors = \
@@ -725,7 +725,7 @@ def get_transform_fxn(data_beads,
         plot_filename = str(data_beads)
 
     # mef_channels and mef_values should be iterables.
-    if hasattr(mef_channels, '__iter__'):
+    if hasattr(mef_channels, '__iter__') and not isinstance(mef_channels, str):
         mef_channels = list(mef_channels)
         mef_values = np.array(mef_values).copy()
     else:

--- a/FlowCal/mef.py
+++ b/FlowCal/mef.py
@@ -6,6 +6,7 @@ Functions for transforming flow cytometer data to MEF units.
 import os
 import functools
 import collections
+import six
 
 import numpy as np
 from scipy.optimize import minimize
@@ -725,7 +726,8 @@ def get_transform_fxn(data_beads,
         plot_filename = str(data_beads)
 
     # mef_channels and mef_values should be iterables.
-    if hasattr(mef_channels, '__iter__') and not isinstance(mef_channels, str):
+    if hasattr(mef_channels, '__iter__') \
+            and not isinstance(mef_channels, six.string_types):
         mef_channels = list(mef_channels)
         mef_values = np.array(mef_values).copy()
     else:

--- a/FlowCal/plot.py
+++ b/FlowCal/plot.py
@@ -59,7 +59,7 @@ from matplotlib.font_manager import FontProperties
 # Use default colors from palettable if available
 try:
     import palettable
-except ImportError, e:
+except ImportError as e:
     cmap_default = plt.get_cmap(matplotlib.rcParams['image.cmap'])
 else:
     cmap_default = palettable.colorbrewer.diverging.Spectral_8_r.mpl_colormap

--- a/FlowCal/transform.py
+++ b/FlowCal/transform.py
@@ -16,6 +16,7 @@ if necessary.
 
 """
 
+import six
 import numpy as np
 
 def transform(data, channels, transform_fxn, def_channels = None):
@@ -59,7 +60,8 @@ def transform(data, channels, transform_fxn, def_channels = None):
             channels = def_channels
 
     # Convert channels to iterable
-    if not (hasattr(channels, '__iter__') and not isinstance(channels, str)):
+    if not (hasattr(channels, '__iter__') \
+            and not isinstance(channels, six.string_types)):
         channels = [channels]
 
     # Apply transformation
@@ -141,7 +143,8 @@ def to_rfi(data,
     if channels is None:
         channels = range(data.shape[1])
 
-    if not (hasattr(channels, '__iter__') and not isinstance(channels, str)):
+    if not (hasattr(channels, '__iter__') \
+            and not isinstance(channels, six.string_types)):
         # If channels is not an iterable, convert it, along with resolution,
         # amplification_type, and amplifier_gain.
         channels = [channels]
@@ -305,7 +308,8 @@ def to_mef(data, channels, sc_list, sc_channels = None):
     if channels is None:
         channels = sc_channels
     # Convert channels to iterable
-    if not (hasattr(channels, '__iter__') and not isinstance(channels, str)):
+    if not (hasattr(channels, '__iter__') \
+            and not isinstance(channels, six.string_types)):
         channels = [channels]
     # Convert channels to index
     if hasattr(data, '_name_to_index'):

--- a/FlowCal/transform.py
+++ b/FlowCal/transform.py
@@ -59,7 +59,7 @@ def transform(data, channels, transform_fxn, def_channels = None):
             channels = def_channels
 
     # Convert channels to iterable
-    if not hasattr(channels, '__iter__'):
+    if not (hasattr(channels, '__iter__') and not isinstance(channels, str)):
         channels = [channels]
 
     # Apply transformation
@@ -141,7 +141,7 @@ def to_rfi(data,
     if channels is None:
         channels = range(data.shape[1])
 
-    if not hasattr(channels, '__iter__'):
+    if not (hasattr(channels, '__iter__') and not isinstance(channels, str)):
         # If channels is not an iterable, convert it, along with resolution,
         # amplification_type, and amplifier_gain.
         channels = [channels]
@@ -305,7 +305,7 @@ def to_mef(data, channels, sc_list, sc_channels = None):
     if channels is None:
         channels = sc_channels
     # Convert channels to iterable
-    if not hasattr(channels, '__iter__'):
+    if not (hasattr(channels, '__iter__') and not isinstance(channels, str)):
         channels = [channels]
     # Convert channels to index
     if hasattr(data, '_name_to_index'):

--- a/doc/getting_started/install_anaconda.rst
+++ b/doc/getting_started/install_anaconda.rst
@@ -3,13 +3,11 @@ Installing FlowCal with Anaconda
 
 To install Anaconda and ``FlowCal``, do the following:
 
-1. Navigate to https://www.continuum.io/downloads. If you are using Windows, click on “Windows 64-bit Graphical Installer” or “Windows 32-bit Graphical Installer” under the “Python 2.7” column, depending on whether your computer is 32-bit or 64-bit. The 64-bit version is strongly recommended. Similarly, if you are using OS X, click on “Mac OS X 64-bit Graphical Installer” under the “Python 2.7” column. This will download the installer.
-
-.. note:: Make sure to download the installer for Python 2.7 and not 3.x. ``FlowCal`` is not currently compatible with Python 3.
+1. Navigate to https://www.continuum.io/downloads. If you are using Windows, click on “64-bit Installer” or “32-bit Installer”, depending on whether your computer is 32-bit or 64-bit. The 64-bit version is strongly recommended. Similarly, if you are using OS X, click on “Graphical Installer”. This will download the installer.
 
 2. Double click the installer (.exe in Windows, .pkg in OS X) and follow the instructions on screen.
 
-.. note:: **Windows**: During installation, on the "Advanced Installation Options" screen, make sure to check both "Add Anaconda to my PATH environment variable" and "Register Anaconda as my default Python 2.7". Recent versions of Anaconda suggest to keep the first option unchecked. However, this option is necessary for the installation script on step 4 to work.
+.. note:: **Windows**: During installation, on the "Advanced Installation Options" screen, make sure to check both "Add Anaconda to my PATH environment variable" and "Register Anaconda as my default Python". Recent versions of Anaconda suggest to keep the first option unchecked. However, this option is necessary for the installation script on step 4 to work.
 
 3. Download ``FlowCal`` from `here <https://github.com/taborlab/FlowCal/archive/master.zip>`_. A file called ``FlowCal-master.zip`` will be downloaded. Unzip this file.
 

--- a/doc/getting_started/install_python.rst
+++ b/doc/getting_started/install_python.rst
@@ -9,12 +9,13 @@ This should take care of all the requirements automatically. Linux and Mac OSX u
 
 Alternatively, download ``FlowCal`` from `here <https://github.com/taborlab/FlowCal/archive/master.zip>`_. Next, make sure that the following Python packages are present:
 
+* ``packaging`` (>=16.8)
+* ``six`` (>=1.10.0)
 * ``numpy`` (>=1.8.2)
 * ``scipy`` (>=0.14.0)
 * ``matplotlib`` (>=1.3.1)
 * ``palettable`` (>=2.1.1)
 * ``scikit-learn`` (>=0.16.0)
-* ``packaging`` (>=16.8)
 * ``pandas`` (>=0.16.1)
 * ``xlrd`` (>=0.9.2)
 * ``XlsxWriter`` (>=0.5.2)

--- a/doc/getting_started/install_python.rst
+++ b/doc/getting_started/install_python.rst
@@ -1,7 +1,7 @@
 Installing FlowCal in an Existing Python Evironment
 =======================================================
 
-Python 2.7 is required, along with ``pip`` and ``setuptools``. The easiest way is to install ``FlowCal`` is to use ``pip``::
+Python (2.7 or 3.6) is required, along with ``pip`` and ``setuptools``. The easiest way is to install ``FlowCal`` is to use ``pip``::
 
 	pip install FlowCal
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
+packaging>=16.8
+six>=1.10.0
 numpy>=1.8.2
 scipy>=0.14.0
 matplotlib>=1.3.1
 palettable>=2.1.1
 scikit-learn>=0.16.0
-packaging>=16.8
 pandas>=0.16.1
 xlrd>=0.9.2
 XlsxWriter>=0.5.2

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.6',
     ],
 
     # What does your project relate to?

--- a/setup.py
+++ b/setup.py
@@ -83,12 +83,13 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['numpy>=1.8.2',
+    install_requires=['packaging>=16.8',
+                      'six>=1.10.0',
+                      'numpy>=1.8.2',
                       'scipy>=0.14.0',
                       'matplotlib>=1.3.1',
                       'palettable>=2.1.1',
                       'scikit-learn>=0.16.0',
-                      'packaging>=16.8',
                       'pandas>=0.16.1',
                       'xlrd>=0.9.2',
                       'XlsxWriter>=0.5.2'],

--- a/test/test_gate.py
+++ b/test/test_gate.py
@@ -569,7 +569,7 @@ class TestDensity2dGate2(unittest.TestCase):
 
         # "slope" with highest density at (4,4)
         d2 = []
-        for idx in xrange(1,5):
+        for idx in range(1,5):
             d2.extend([(x,y) for x in range(idx,5) for y in range(idx,5)])
         self.slope = np.array(d2)
 

--- a/test/test_gate.py
+++ b/test/test_gate.py
@@ -100,7 +100,7 @@ class TestStartEndGate(unittest.TestCase):
 class TestHighLowGate(unittest.TestCase):
     
     def setUp(self):
-        self.d1 = np.array([range(1,11)]).T
+        self.d1 = np.array([list(range(1,11))]).T
         self.d2 = np.array([
             [1, 7, 2],
             [2, 8, 3],
@@ -1144,7 +1144,7 @@ class TestDensity2dGate2(unittest.TestCase):
     # as opposed to all other bins intervals which are half-open).
 
     def test_bins_edge_case_1_gated_data_1(self):
-        bins = range(5)
+        bins = list(range(5))
         np.testing.assert_array_equal(
             FlowCal.gate.density2d(
                 self.pyramid, bins=bins, gate_fraction=4.0/31, sigma=0.0),
@@ -1157,7 +1157,7 @@ class TestDensity2dGate2(unittest.TestCase):
             )
 
     def test_bins_edge_case_1_gated_data_2(self):
-        bins = range(5)
+        bins = list(range(5))
         np.testing.assert_array_equal(
             FlowCal.gate.density2d(
                 self.pyramid, bins=bins, gate_fraction=4.0/31, sigma=0.0,
@@ -1171,7 +1171,7 @@ class TestDensity2dGate2(unittest.TestCase):
             )
 
     def test_bins_edge_case_1_mask(self):
-        bins = range(5)
+        bins = list(range(5))
         np.testing.assert_array_equal(
             FlowCal.gate.density2d(
                 self.pyramid, bins=bins, gate_fraction=4.0/31, sigma=0.0,
@@ -1181,7 +1181,7 @@ class TestDensity2dGate2(unittest.TestCase):
             )
 
     def test_bins_edge_case_2_gated_data_1(self):
-        bins = range(5)
+        bins = list(range(5))
         np.testing.assert_array_equal(
             FlowCal.gate.density2d(
                 self.pyramid, bins=bins, gate_fraction=13.0/31, sigma=0.0),
@@ -1203,7 +1203,7 @@ class TestDensity2dGate2(unittest.TestCase):
             )
 
     def test_bins_edge_case_2_gated_data_2(self):
-        bins = range(5)
+        bins = list(range(5))
         np.testing.assert_array_equal(
             FlowCal.gate.density2d(
                 self.pyramid, bins=bins, gate_fraction=13.0/31, sigma=0.0,
@@ -1226,7 +1226,7 @@ class TestDensity2dGate2(unittest.TestCase):
             )
 
     def test_bins_edge_case_2_mask(self):
-        bins = range(5)
+        bins = list(range(5))
         np.testing.assert_array_equal(
             FlowCal.gate.density2d(
                 self.pyramid, bins=bins, gate_fraction=13.0/31, sigma=0.0,

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -2489,7 +2489,7 @@ class TestFCSDataSlicing(unittest.TestCase):
         Testing the 1D slicing with a list of a FCSData object.
 
         """
-        ds = self.d[range(10)]
+        ds = self.d[list(range(10))]
         self.assertIsInstance(ds, FlowCal.io.FCSData)
         self.assertEqual(ds.shape, (10,6))
         self.assertEqual(ds.channels,

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -5,7 +5,21 @@ Unit tests for the `io` module.
 
 import datetime
 import unittest
-import StringIO
+import sys
+
+# In Python 2.7, StringIO mimics the output of a file stream in 'rb' more (the
+# output of .read() is a string). In Python 3, a file stream's output in 'rb'
+# mode is a bytearray, so the corresponding in-memory stream is BytesIO.
+# However, a BytesIO cannot be created from a string directly, which is why we
+# need to call .encode().
+if sys.version_info.major == 2:
+    from StringIO import StringIO
+    def get_buffered_stream(s):
+        return StringIO(s)
+elif sys.version_info.major == 3:
+    from io import BytesIO
+    def get_buffered_stream(s):
+        return BytesIO(s.encode())
 
 import numpy as np
 
@@ -123,7 +137,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/'
         delim            = '/'
         text_dict        = {'k1':'v1'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -139,7 +153,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -158,7 +172,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/     '
         delim            = '/'
         text_dict        = {'k1':'v1'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -176,7 +190,7 @@ class TestReadTextSegment(unittest.TestCase):
         """
         raw_text_segment = '/k1/v1/'
         delim            = '|'
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertRaises(
             ValueError,
             FlowCal.io.read_fcs_text_segment,
@@ -190,7 +204,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/key//1/value1/k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'key/1':'value1','k2':'v2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -206,7 +220,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/key1/value//1/k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'key1':'value/1','k2':'v2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -222,7 +236,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/key//2/value2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','key/2':'value2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -238,7 +252,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/key2/value//2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','key2':'value/2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -254,7 +268,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/key//3/value3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','key/3':'value3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -270,7 +284,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/key3/value//3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','key3':'value/3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -285,7 +299,7 @@ class TestReadTextSegment(unittest.TestCase):
         """
         raw_text_segment = '///key1/value1/k2/v2/k3/v3/'
         delim            = '/'
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertRaises(
             ValueError,
             FlowCal.io.read_fcs_text_segment,
@@ -299,7 +313,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/key1///value1/k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'key1/':'value1','k2':'v2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -315,7 +329,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1///key2/value2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1/','key2':'value2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -331,7 +345,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/key2///value2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','key2/':'value2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -347,7 +361,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2///key3/value3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2/','key3':'value3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -363,7 +377,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/key3///value3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','key3/':'value3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -379,7 +393,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/k3/v3///'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v3/'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -395,7 +409,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/k3/v3//'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -411,7 +425,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k////1/v1/k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'k//1':'v1','k2':'v2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -427,7 +441,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v//1///k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v/1/','k2':'v2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -443,7 +457,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k//2/////v2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k/2//':'v2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -459,7 +473,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v//////2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v///2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -475,7 +489,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/k////3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k//3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -491,7 +505,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/k3/v////3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v//3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -507,7 +521,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/k3/v3/////'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v3//'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -522,7 +536,7 @@ class TestReadTextSegment(unittest.TestCase):
         """
         raw_text_segment = '/////k1/v1/k2/v2/k3/v3/'
         delim            = '/'
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertRaises(
             ValueError,
             FlowCal.io.read_fcs_text_segment,
@@ -540,7 +554,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/'
         delim            = '/'
         text_dict        = {'k1':'v1'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -558,7 +572,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1/'
         delim            = '/'
         text_dict        = {'k1':'v1'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -576,7 +590,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/'
         delim            = '/'
         text_dict        = {'k1':'v1'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertRaises(
             ValueError,
             FlowCal.io.read_fcs_text_segment,
@@ -590,7 +604,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -608,7 +622,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1/k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -629,7 +643,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/     '
         delim            = '/'
         text_dict        = {'k1':'v1'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -650,7 +664,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1/     '
         delim            = '/'
         text_dict        = {'k1':'v1'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -668,7 +682,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/key//1/value1/k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'key/1':'value1','k2':'v2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -686,7 +700,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'key//1/value1/k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'key/1':'value1','k2':'v2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -704,7 +718,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/key1/value//1/k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'key1':'value/1','k2':'v2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -722,7 +736,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'key1/value//1/k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'key1':'value/1','k2':'v2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -740,7 +754,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/key//2/value2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','key/2':'value2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -758,7 +772,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1/key//2/value2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','key/2':'value2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -776,7 +790,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/key2/value//2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','key2':'value/2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -794,7 +808,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1/key2/value//2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','key2':'value/2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -812,7 +826,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/key//3/value3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','key/3':'value3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -830,7 +844,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1/k2/v2/key//3/value3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','key/3':'value3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -848,7 +862,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/key3/value//3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','key3':'value/3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -866,7 +880,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1/k2/v2/key3/value//3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','key3':'value/3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -883,7 +897,7 @@ class TestReadTextSegment(unittest.TestCase):
         """
         raw_text_segment = '///key1/value1/k2/v2/k3/v3/'
         delim            = '/'
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertRaises(
             ValueError,
             FlowCal.io.read_fcs_text_segment,
@@ -897,7 +911,7 @@ class TestReadTextSegment(unittest.TestCase):
         """
         raw_text_segment = '//key1/value1/k2/v2/k3/v3/'
         delim            = '/'
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertRaises(
             ValueError,
             FlowCal.io.read_fcs_text_segment,
@@ -912,7 +926,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/key1///value1/k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'key1/':'value1','k2':'v2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -930,7 +944,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'key1///value1/k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'key1/':'value1','k2':'v2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -948,7 +962,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1///key2/value2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1/','key2':'value2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -966,7 +980,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1///key2/value2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1/','key2':'value2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -984,7 +998,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/key2///value2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','key2/':'value2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1002,7 +1016,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1/key2///value2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','key2/':'value2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1020,7 +1034,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2///key3/value3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2/','key3':'value3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1038,7 +1052,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1/k2/v2///key3/value3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2/','key3':'value3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1056,7 +1070,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/key3///value3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','key3/':'value3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1074,7 +1088,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1/k2/v2/key3///value3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','key3/':'value3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1092,7 +1106,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/k3/v3///'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v3/'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1110,7 +1124,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1/k2/v2/k3/v3///'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v3/'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1128,7 +1142,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/k3/v3//'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1146,7 +1160,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1/k2/v2/k3/v3//'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1164,7 +1178,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k////1/v1/k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'k//1':'v1','k2':'v2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1182,7 +1196,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k////1/v1/k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'k//1':'v1','k2':'v2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1200,7 +1214,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v//1///k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v/1/','k2':'v2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1218,7 +1232,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v//1///k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v/1/','k2':'v2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1236,7 +1250,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k//2/////v2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k/2//':'v2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1254,7 +1268,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1/k//2/////v2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k/2//':'v2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1272,7 +1286,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v//////2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v///2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1290,7 +1304,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1/k2/v//////2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v///2','k3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1308,7 +1322,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/k////3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k//3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1326,7 +1340,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1/k2/v2/k////3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k//3':'v3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1344,7 +1358,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/k3/v////3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v//3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1362,7 +1376,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1/k2/v2/k3/v////3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v//3'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1380,7 +1394,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/k3/v3/////'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v3//'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1398,7 +1412,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1/k2/v2/k3/v3/////'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v3//'}
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1415,7 +1429,7 @@ class TestReadTextSegment(unittest.TestCase):
         """
         raw_text_segment = '/////k1/v1/k2/v2/k3/v3/'
         delim            = '/'
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertRaises(
             ValueError,
             FlowCal.io.read_fcs_text_segment,
@@ -1429,7 +1443,7 @@ class TestReadTextSegment(unittest.TestCase):
         """
         raw_text_segment = '////k1/v1/k2/v2/k3/v3/'
         delim            = '/'
-        buf              = StringIO.StringIO(raw_text_segment)
+        buf              = get_buffered_stream(raw_text_segment)
         self.assertRaises(
             ValueError,
             FlowCal.io.read_fcs_text_segment,

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -5,21 +5,7 @@ Unit tests for the `io` module.
 
 import datetime
 import unittest
-import sys
-
-# In Python 2.7, StringIO mimics the output of a file stream in 'rb' more (the
-# output of .read() is a string). In Python 3, a file stream's output in 'rb'
-# mode is a bytearray, so the corresponding in-memory stream is BytesIO.
-# However, a BytesIO cannot be created from a string directly, which is why we
-# need to call .encode().
-if sys.version_info.major == 2:
-    from StringIO import StringIO
-    def get_buffered_stream(s):
-        return StringIO(s)
-elif sys.version_info.major == 3:
-    from io import BytesIO
-    def get_buffered_stream(s):
-        return BytesIO(s.encode())
+import six
 
 import numpy as np
 
@@ -137,7 +123,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/'
         delim            = '/'
         text_dict        = {'k1':'v1'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -153,7 +139,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -172,7 +158,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/     '
         delim            = '/'
         text_dict        = {'k1':'v1'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -190,7 +176,7 @@ class TestReadTextSegment(unittest.TestCase):
         """
         raw_text_segment = '/k1/v1/'
         delim            = '|'
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertRaises(
             ValueError,
             FlowCal.io.read_fcs_text_segment,
@@ -204,7 +190,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/key//1/value1/k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'key/1':'value1','k2':'v2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -220,7 +206,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/key1/value//1/k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'key1':'value/1','k2':'v2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -236,7 +222,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/key//2/value2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','key/2':'value2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -252,7 +238,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/key2/value//2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','key2':'value/2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -268,7 +254,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/key//3/value3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','key/3':'value3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -284,7 +270,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/key3/value//3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','key3':'value/3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -299,7 +285,7 @@ class TestReadTextSegment(unittest.TestCase):
         """
         raw_text_segment = '///key1/value1/k2/v2/k3/v3/'
         delim            = '/'
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertRaises(
             ValueError,
             FlowCal.io.read_fcs_text_segment,
@@ -313,7 +299,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/key1///value1/k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'key1/':'value1','k2':'v2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -329,7 +315,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1///key2/value2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1/','key2':'value2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -345,7 +331,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/key2///value2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','key2/':'value2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -361,7 +347,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2///key3/value3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2/','key3':'value3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -377,7 +363,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/key3///value3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','key3/':'value3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -393,7 +379,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/k3/v3///'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v3/'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -409,7 +395,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/k3/v3//'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -425,7 +411,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k////1/v1/k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'k//1':'v1','k2':'v2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -441,7 +427,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v//1///k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v/1/','k2':'v2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -457,7 +443,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k//2/////v2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k/2//':'v2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -473,7 +459,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v//////2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v///2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -489,7 +475,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/k////3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k//3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -505,7 +491,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/k3/v////3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v//3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -521,7 +507,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/k3/v3/////'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v3//'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -536,7 +522,7 @@ class TestReadTextSegment(unittest.TestCase):
         """
         raw_text_segment = '/////k1/v1/k2/v2/k3/v3/'
         delim            = '/'
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertRaises(
             ValueError,
             FlowCal.io.read_fcs_text_segment,
@@ -554,7 +540,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/'
         delim            = '/'
         text_dict        = {'k1':'v1'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -572,7 +558,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1/'
         delim            = '/'
         text_dict        = {'k1':'v1'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -590,7 +576,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/'
         delim            = '/'
         text_dict        = {'k1':'v1'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertRaises(
             ValueError,
             FlowCal.io.read_fcs_text_segment,
@@ -604,7 +590,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -622,7 +608,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1/k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -643,7 +629,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/     '
         delim            = '/'
         text_dict        = {'k1':'v1'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -664,7 +650,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1/     '
         delim            = '/'
         text_dict        = {'k1':'v1'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -682,7 +668,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/key//1/value1/k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'key/1':'value1','k2':'v2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -700,7 +686,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'key//1/value1/k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'key/1':'value1','k2':'v2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -718,7 +704,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/key1/value//1/k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'key1':'value/1','k2':'v2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -736,7 +722,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'key1/value//1/k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'key1':'value/1','k2':'v2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -754,7 +740,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/key//2/value2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','key/2':'value2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -772,7 +758,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1/key//2/value2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','key/2':'value2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -790,7 +776,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/key2/value//2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','key2':'value/2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -808,7 +794,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1/key2/value//2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','key2':'value/2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -826,7 +812,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/key//3/value3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','key/3':'value3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -844,7 +830,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1/k2/v2/key//3/value3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','key/3':'value3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -862,7 +848,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/key3/value//3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','key3':'value/3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -880,7 +866,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1/k2/v2/key3/value//3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','key3':'value/3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -897,7 +883,7 @@ class TestReadTextSegment(unittest.TestCase):
         """
         raw_text_segment = '///key1/value1/k2/v2/k3/v3/'
         delim            = '/'
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertRaises(
             ValueError,
             FlowCal.io.read_fcs_text_segment,
@@ -911,7 +897,7 @@ class TestReadTextSegment(unittest.TestCase):
         """
         raw_text_segment = '//key1/value1/k2/v2/k3/v3/'
         delim            = '/'
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertRaises(
             ValueError,
             FlowCal.io.read_fcs_text_segment,
@@ -926,7 +912,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/key1///value1/k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'key1/':'value1','k2':'v2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -944,7 +930,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'key1///value1/k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'key1/':'value1','k2':'v2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -962,7 +948,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1///key2/value2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1/','key2':'value2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -980,7 +966,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1///key2/value2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1/','key2':'value2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -998,7 +984,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/key2///value2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','key2/':'value2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1016,7 +1002,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1/key2///value2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','key2/':'value2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1034,7 +1020,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2///key3/value3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2/','key3':'value3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1052,7 +1038,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1/k2/v2///key3/value3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2/','key3':'value3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1070,7 +1056,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/key3///value3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','key3/':'value3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1088,7 +1074,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1/k2/v2/key3///value3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','key3/':'value3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1106,7 +1092,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/k3/v3///'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v3/'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1124,7 +1110,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1/k2/v2/k3/v3///'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v3/'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1142,7 +1128,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/k3/v3//'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1160,7 +1146,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1/k2/v2/k3/v3//'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1178,7 +1164,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k////1/v1/k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'k//1':'v1','k2':'v2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1196,7 +1182,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k////1/v1/k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'k//1':'v1','k2':'v2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1214,7 +1200,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v//1///k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v/1/','k2':'v2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1232,7 +1218,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v//1///k2/v2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v/1/','k2':'v2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1250,7 +1236,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k//2/////v2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k/2//':'v2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1268,7 +1254,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1/k//2/////v2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k/2//':'v2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1286,7 +1272,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v//////2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v///2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1304,7 +1290,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1/k2/v//////2/k3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v///2','k3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1322,7 +1308,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/k////3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k//3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1340,7 +1326,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1/k2/v2/k////3/v3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k//3':'v3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1358,7 +1344,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/k3/v////3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v//3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1376,7 +1362,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1/k2/v2/k3/v////3/'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v//3'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1394,7 +1380,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = '/k1/v1/k2/v2/k3/v3/////'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v3//'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1412,7 +1398,7 @@ class TestReadTextSegment(unittest.TestCase):
         raw_text_segment = 'k1/v1/k2/v2/k3/v3/////'
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v3//'}
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertEqual(
             FlowCal.io.read_fcs_text_segment(
                 buf=buf,
@@ -1429,7 +1415,7 @@ class TestReadTextSegment(unittest.TestCase):
         """
         raw_text_segment = '/////k1/v1/k2/v2/k3/v3/'
         delim            = '/'
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertRaises(
             ValueError,
             FlowCal.io.read_fcs_text_segment,
@@ -1443,7 +1429,7 @@ class TestReadTextSegment(unittest.TestCase):
         """
         raw_text_segment = '////k1/v1/k2/v2/k3/v3/'
         delim            = '/'
-        buf              = get_buffered_stream(raw_text_segment)
+        buf              = six.BytesIO(six.b(raw_text_segment))
         self.assertRaises(
             ValueError,
             FlowCal.io.read_fcs_text_segment,


### PR DESCRIPTION
Solves #264. Tested on python 3.5 and 3.6. Unit tests pass, with a few warning messages (same as current develop (893acba3378e493829712a625e80758024bd60aa) with python 2.7). Example files run through the Excel UI and produce the appropriate output.