### PR TITLE
add entrypoints

### DIFF
--- a/FlowCal/excel_ui.py
+++ b/FlowCal/excel_ui.py
@@ -70,6 +70,7 @@ ignored by ``FlowCal``.
 """
 
 import collections
+import sys
 import os
 import os.path
 import packaging
@@ -266,7 +267,7 @@ def process_beads_table(beads_table,
         - Generate forward/side scatter density plots and fluorescence
           histograms, and plots of the clustering and fitting steps of
           standard curve generation, if `plot` = True.
-    
+
     Names of forward/side scatter and fluorescence channels are taken from
     `instruments_table`.
 
@@ -593,7 +594,7 @@ def process_samples_table(samples_table,
           channels.
         - Plot combined forward/side scatter density plots and fluorescence
           historgrams, if `plot` = True.
-    
+
     Names of forward/side scatter and fluorescence channels are taken from
     `instruments_table`.
 
@@ -860,7 +861,7 @@ def process_samples_table(samples_table,
                     else:
                         param['xscale'] = 'logicle'
                     hist_params.append(param)
-                    
+
                 # Plot
                 if plot_dir is not None:
                     figname = os.path.join(
@@ -1035,7 +1036,7 @@ def add_samples_stats(samples_table, samples):
         - Notes (warnings, errors) resulting from the analysis
         - Number of Events
         - Acquisition Time (s)
-    
+
     The following information is added for each row, for each channel in
     which fluorescence units have been specified:
 
@@ -1209,7 +1210,7 @@ def generate_histograms_table(samples_table, samples, max_bins=1024):
         should correspond to ``samples_table.iloc[i]``
     max_bins : int, optional
         Maximum number of bins to use.
-    
+
     Returns
     -------
     hist_table : DataFrame
@@ -1489,9 +1490,10 @@ def run(input_path=None,
     if verbose:
         print("\nDone.")
 
-if __name__ == '__main__':
-    # Read command line arguments
+
+def main(args=sys.argv):
     import argparse
+    # Read command line arguments
     parser = argparse.ArgumentParser(
         description="process flow cytometry files with FlowCal's Excel UI.")
     parser.add_argument(
@@ -1521,7 +1523,7 @@ if __name__ == '__main__':
         "--histogram-sheet",
         action="store_true",
         help="generate sheet in output Excel file specifying histogram bins")
-    args = parser.parse_args()
+    args = parser.parse_args(args)
 
     # Run Excel UI
     run(input_path=args.inputpath,
@@ -1529,3 +1531,6 @@ if __name__ == '__main__':
         verbose=args.verbose,
         plot=args.plot,
         hist_sheet=args.histogram_sheet)
+
+if __name__ == '__main__':
+    main()

--- a/FlowCal/excel_ui.py
+++ b/FlowCal/excel_ui.py
@@ -1491,7 +1491,7 @@ def run(input_path=None,
         print("\nDone.")
 
 
-def main(argv=None):
+def run_command_line(argv=None):
     """
     Entry point for the FlowCal and flowcal console scripts
 
@@ -1555,4 +1555,4 @@ def main(argv=None):
         hist_sheet=args.histogram_sheet)
 
 if __name__ == '__main__':
-    main()
+    run_command_line()

--- a/FlowCal/excel_ui.py
+++ b/FlowCal/excel_ui.py
@@ -1491,7 +1491,29 @@ def run(input_path=None,
         print("\nDone.")
 
 
-def main(args=sys.argv):
+def main(argv=None):
+    """
+    Entry point for the FlowCal and flowcal console scripts
+
+    Parameters
+    ----------
+    argv: list of strings
+        argument values to parse and pass to run()
+
+    Notes
+    ----------
+    Use main(argv = ['arguments', 'you', 'want', 'to', 'test'])
+    to test entry point and argument parsing in unit tests
+
+    See Also
+    ----------
+    FlowCal.excel_ui.run()
+
+    http://amir.rachum.com/blog/2017/07/28/python-entry-points/
+
+    """
+    if argv == None:
+        argv = sys.argv
     import argparse
     # Read command line arguments
     parser = argparse.ArgumentParser(
@@ -1523,7 +1545,7 @@ def main(args=sys.argv):
         "--histogram-sheet",
         action="store_true",
         help="generate sheet in output Excel file specifying histogram bins")
-    args = parser.parse_args(args)
+    args = parser.parse_args(args=argv)
 
     # Run Excel UI
     run(input_path=args.inputpath,

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,9 @@ setup(
     name='FlowCal',
 
     entry_points = {
-        'console_scripts': ['FlowCal=FlowCal.excel_ui:main',
-                            'flowcal=FlowCal.excel_ui:main'],
+        'console_scripts': [
+            'flowcal=FlowCal.excel_ui:run_command_line'
+        ]
     },
 
     # Versions should comply with PEP440.  For a discussion on single-sourcing

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 # setuptools setup module.
-# 
+#
 # Based on setup.py on https://github.com/pypa/sampleproject.
 
 from setuptools import setup, find_packages
@@ -33,6 +33,11 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='FlowCal',
+
+    entry_points = {
+        'console_scripts': ['FlowCal=FlowCal.excel_ui:main',
+                            'flowcal=FlowCal.excel_ui:main'],
+    },
 
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see


### PR DESCRIPTION
- added entrypoints `flowcal` and `FlowCal` to launch `excel_ui` in `setup.py`
- refactored `FlowCal/excel_ui.py` to accomodate those changes
    - added main function
    - imported sys
    - my editor automatically clears lines with only tabs and spaces. Sorry for the mess

Tested in fresh anaconda python3 and python2 environments on Ubuntu Linux 16.10.