### PR TITLE
Added entrypoints to command line scripts

### DIFF
--- a/FlowCal/excel_ui.py
+++ b/FlowCal/excel_ui.py
@@ -70,6 +70,7 @@ ignored by ``FlowCal``.
 """
 
 import collections
+import sys
 import os
 import os.path
 import packaging
@@ -266,7 +267,7 @@ def process_beads_table(beads_table,
         - Generate forward/side scatter density plots and fluorescence
           histograms, and plots of the clustering and fitting steps of
           standard curve generation, if `plot` = True.
-    
+
     Names of forward/side scatter and fluorescence channels are taken from
     `instruments_table`.
 
@@ -593,7 +594,7 @@ def process_samples_table(samples_table,
           channels.
         - Plot combined forward/side scatter density plots and fluorescence
           historgrams, if `plot` = True.
-    
+
     Names of forward/side scatter and fluorescence channels are taken from
     `instruments_table`.
 
@@ -860,7 +861,7 @@ def process_samples_table(samples_table,
                     else:
                         param['xscale'] = 'logicle'
                     hist_params.append(param)
-                    
+
                 # Plot
                 if plot_dir is not None:
                     figname = os.path.join(
@@ -1035,7 +1036,7 @@ def add_samples_stats(samples_table, samples):
         - Notes (warnings, errors) resulting from the analysis
         - Number of Events
         - Acquisition Time (s)
-    
+
     The following information is added for each row, for each channel in
     which fluorescence units have been specified:
 
@@ -1209,7 +1210,7 @@ def generate_histograms_table(samples_table, samples, max_bins=1024):
         should correspond to ``samples_table.iloc[i]``
     max_bins : int, optional
         Maximum number of bins to use.
-    
+
     Returns
     -------
     hist_table : DataFrame
@@ -1489,9 +1490,10 @@ def run(input_path=None,
     if verbose:
         print("\nDone.")
 
-if __name__ == '__main__':
-    # Read command line arguments
+
+def main(args=sys.argv):
     import argparse
+    # Read command line arguments
     parser = argparse.ArgumentParser(
         description="process flow cytometry files with FlowCal's Excel UI.")
     parser.add_argument(
@@ -1521,7 +1523,7 @@ if __name__ == '__main__':
         "--histogram-sheet",
         action="store_true",
         help="generate sheet in output Excel file specifying histogram bins")
-    args = parser.parse_args()
+    args = parser.parse_args(args)
 
     # Run Excel UI
     run(input_path=args.inputpath,
@@ -1529,3 +1531,6 @@ if __name__ == '__main__':
         verbose=args.verbose,
         plot=args.plot,
         hist_sheet=args.histogram_sheet)
+
+if __name__ == '__main__':
+    main()

--- a/FlowCal/excel_ui.py
+++ b/FlowCal/excel_ui.py
@@ -1491,7 +1491,7 @@ def run(input_path=None,
         print("\nDone.")
 
 
-def main(argv=None):
+def run_command_line(argv=None):
     """
     Entry point for the FlowCal and flowcal console scripts
 
@@ -1555,4 +1555,4 @@ def main(argv=None):
         hist_sheet=args.histogram_sheet)
 
 if __name__ == '__main__':
-    main()
+    run_command_line()

--- a/FlowCal/excel_ui.py
+++ b/FlowCal/excel_ui.py
@@ -1491,19 +1491,15 @@ def run(input_path=None,
         print("\nDone.")
 
 
-def run_command_line(argv=None):
+def run_command_line(args=None):
     """
-    Entry point for the FlowCal and flowcal console scripts
+    Entry point for the FlowCal and flowcal console scripts.
 
     Parameters
     ----------
-    argv: list of strings
-        argument values to parse and pass to run()
-
-    Notes
-    ----------
-    Use main(argv = ['arguments', 'you', 'want', 'to', 'test'])
-    to test entry point and argument parsing in unit tests
+    args: list of strings, optional
+        Command line arguments. If None or not specified, get arguments
+        from ``sys.argv``.
 
     See Also
     ----------
@@ -1512,8 +1508,13 @@ def run_command_line(argv=None):
     http://amir.rachum.com/blog/2017/07/28/python-entry-points/
 
     """
-    if argv == None:
-        argv = sys.argv
+    # Get arguments from ``sys.argv`` if necessary.
+    # ``sys.argv`` has the name of the script as its first element. We do not
+    # need this, and in fact if present, it will later break
+    # ``parser.parse_args()``.
+    if args is None:
+        args = sys.argv[1:]
+
     import argparse
     # Read command line arguments
     parser = argparse.ArgumentParser(
@@ -1545,7 +1546,7 @@ def run_command_line(argv=None):
         "--histogram-sheet",
         action="store_true",
         help="generate sheet in output Excel file specifying histogram bins")
-    args = parser.parse_args(args=argv)
+    args = parser.parse_args(args=args)
 
     # Run Excel UI
     run(input_path=args.inputpath,

--- a/FlowCal/excel_ui.py
+++ b/FlowCal/excel_ui.py
@@ -1491,7 +1491,29 @@ def run(input_path=None,
         print("\nDone.")
 
 
-def main(args=sys.argv):
+def main(argv=None):
+    """
+    Entry point for the FlowCal and flowcal console scripts
+
+    Parameters
+    ----------
+    argv: list of strings
+        argument values to parse and pass to run()
+
+    Notes
+    ----------
+    Use main(argv = ['arguments', 'you', 'want', 'to', 'test'])
+    to test entry point and argument parsing in unit tests
+
+    See Also
+    ----------
+    FlowCal.excel_ui.run()
+
+    http://amir.rachum.com/blog/2017/07/28/python-entry-points/
+
+    """
+    if argv == None:
+        argv = sys.argv
     import argparse
     # Read command line arguments
     parser = argparse.ArgumentParser(
@@ -1523,7 +1545,7 @@ def main(args=sys.argv):
         "--histogram-sheet",
         action="store_true",
         help="generate sheet in output Excel file specifying histogram bins")
-    args = parser.parse_args(args)
+    args = parser.parse_args(args=argv)
 
     # Run Excel UI
     run(input_path=args.inputpath,

--- a/FlowCal/excel_ui.py
+++ b/FlowCal/excel_ui.py
@@ -1509,9 +1509,10 @@ def run_command_line(args=None):
 
     """
     # Get arguments from ``sys.argv`` if necessary.
-    # ``sys.argv`` has the name of the script as its first element. We do not
-    # need this, and in fact if present, it will later break
-    # ``parser.parse_args()``.
+    # ``sys.argv`` has the name of the script as its first element. We remove
+    # this element because it will break ``parser.parse_args()`` later. In fact,
+    # ``parser.parse_args()``, if provided with no arguments, will also use
+    # ``sys.argv`` after removing the first element.
     if args is None:
         args = sys.argv[1:]
 

--- a/doc/excel_ui/cmd_interface.rst
+++ b/doc/excel_ui/cmd_interface.rst
@@ -1,28 +1,35 @@
 Command Line Interface (Advanced)
 =================================
 
-The Excel UI can be run from a command line interpreter with the following statement::
+The Excel UI can be run from a command line interpreter with one of the following equivalent statements::
 
-	python -m FlowCal.excel_ui [-h] [-i [INPUTPATH]] [-o [OUTPUTPATH]] [-v] [-p]
+	flowcal [-h] [-i [INPUTPATH]] [-o [OUTPUTPATH]] [-v] [-p] [-H]
+	FlowCal [-h] [-i [INPUTPATH]] [-o [OUTPUTPATH]] [-v] [-p] [-H]
+	python -m FlowCal.excel_ui [-h] [-i [INPUTPATH]] [-o [OUTPUTPATH]] [-v] [-p] [-H]
 
 Where the flags are::
 
-	-i, --inputpath
-	 	input Excel file name. If not specified, show open file window
-	-o, --outputpath
-	 	output Excel file name. If not specified, use [INPUTPATH]_output
-	-v=False, --verbose=False
-	 	print information about individual processing steps
-	-p=False, --plot=False
-	 	generate and save density plots/histograms of beads and samples
-	-h, --help
-		show this help message and exit
+    -h, --help            show this help message and exit
+    -i [INPUTPATH], --inputpath [INPUTPATH]
+                          input Excel file name. If not specified, show open
+                          file window
+    -o [OUTPUTPATH], --outputpath [OUTPUTPATH]
+                          output Excel file name. If not specified, use
+                          [INPUTPATH]_output
+    -v, --verbose         print information about individual processing steps
+    -p, --plot            generate and save density plots/histograms of beads
+                          and samples
+    -H, --histogram-sheet
+                          generate sheet in output Excel file specifying
+                          histogram bins
 
 Running ``FlowCal``'s Excel UI without any flags will show the open file dialog to select an :doc:`input Excel file <input_format>`. Once a file is selected, FlowCal will generate an :doc:`output Excel file <outputs>`. In contrast to using ``Run FlowCal (OSX)`` or ``Run FlowCal (Windows).bat``, the statement above with no flags will not display any messages during processing or generate any plots. To display messages and generate plots, use::
 
-	python -m FlowCal.excel_ui -v -p
+	flowcal -v -p
 
-``Run FlowCal (OSX)`` and ``Run FlowCal (Windows).bat`` use, in fact, this statement.
+``Run FlowCal (OSX)`` and ``Run FlowCal (Windows).bat`` use, in fact, the following equivalent statement::
+
+	python -m FlowCal.excel_ui -v -p
 
 .. note::
 	In Mac OSX, a critical error may appear when trying to run the Excel UI from the command line. The error message is quite long, but one of the last lines reads similarly to this::
@@ -39,7 +46,7 @@ Running ``FlowCal``'s Excel UI without any flags will show the open file dialog 
 
 Using the command line arguments, one can create a batch script to process several Excel files at once, each pointing to a different set of FCS files. Such script would have the form::
 
-	python -m FlowCal.excel_ui -i input_excel_file_1.xlsx -o output_excel_file_1.xlsx
-	python -m FlowCal.excel_ui -i input_excel_file_2.xlsx -o output_excel_file_2.xlsx
-	python -m FlowCal.excel_ui -i input_excel_file_3.xlsx -o output_excel_file_3.xlsx
+	flowcal -i input_excel_file_1.xlsx -o output_excel_file_1.xlsx
+	flowcal -i input_excel_file_2.xlsx -o output_excel_file_2.xlsx
+	flowcal -i input_excel_file_3.xlsx -o output_excel_file_3.xlsx
 	...

--- a/doc/excel_ui/cmd_interface.rst
+++ b/doc/excel_ui/cmd_interface.rst
@@ -4,7 +4,6 @@ Command Line Interface (Advanced)
 The Excel UI can be run from a command line interpreter with one of the following equivalent statements::
 
 	flowcal [-h] [-i [INPUTPATH]] [-o [OUTPUTPATH]] [-v] [-p] [-H]
-	FlowCal [-h] [-i [INPUTPATH]] [-o [OUTPUTPATH]] [-v] [-p] [-H]
 	python -m FlowCal.excel_ui [-h] [-i [INPUTPATH]] [-o [OUTPUTPATH]] [-v] [-p] [-H]
 
 Where the flags are::

--- a/setup.py
+++ b/setup.py
@@ -34,12 +34,6 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 setup(
     name='FlowCal',
 
-    entry_points = {
-        'console_scripts': [
-            'flowcal=FlowCal.excel_ui:run_command_line'
-        ]
-    },
-
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
@@ -127,9 +121,10 @@ setup(
     # To provide executable scripts, use entry points in preference to the
     # "scripts" keyword. Entry points provide cross-platform support and allow
     # pip to create the appropriate form of executable for the target platform.
-    # entry_points={
-    #     'console_scripts': [
-    #         'sample=sample:main',
-    #     ],
-    # },
+    entry_points = {
+        'console_scripts': [
+            'flowcal=FlowCal.excel_ui:run_command_line',
+            'FlowCal=FlowCal.excel_ui:run_command_line',
+        ]
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,6 @@ setup(
     entry_points = {
         'console_scripts': [
             'flowcal=FlowCal.excel_ui:run_command_line',
-            'FlowCal=FlowCal.excel_ui:run_command_line',
         ]
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,9 @@ setup(
     name='FlowCal',
 
     entry_points = {
-        'console_scripts': ['FlowCal=FlowCal.excel_ui:main',
-                            'flowcal=FlowCal.excel_ui:main'],
+        'console_scripts': [
+            'flowcal=FlowCal.excel_ui:run_command_line'
+        ]
     },
 
     # Versions should comply with PEP440.  For a discussion on single-sourcing

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 # setuptools setup module.
-# 
+#
 # Based on setup.py on https://github.com/pypa/sampleproject.
 
 from setuptools import setup, find_packages
@@ -33,6 +33,11 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='FlowCal',
+
+    entry_points = {
+        'console_scripts': ['FlowCal=FlowCal.excel_ui:main',
+                            'flowcal=FlowCal.excel_ui:main'],
+    },
 
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see


### PR DESCRIPTION
Solves #273.
- Adds two entrypoints for command line scripts, ``flowcal`` and ``FlowCal``, for the Excel UI CLI that can be used instead of the more verbose ``python -m FlowCal.excel_ui``.
- Reorganized the contents of ``excel_ui.py`` so that processing of command line arguments is made in a separate function that serves as the entry point.
- Updated documentation to reflect new Excel UI CLI.

This is continued from PR #274. A lot of the work was done there by @renxida, but the final code didn't work in my hands. To accelerate iteration, I made a new branch from his commits and committed on top. Original commits and authorship will be preserved after merging of this PR.