### PR TITLE
Made explicit in `plot.hist1d()` that `normed_height` is ignored when `normed_area=True`

### DIFF
--- a/FlowCal/plot.py
+++ b/FlowCal/plot.py
@@ -885,7 +885,7 @@ def hist1d(data_list,
                                    **xscale_kwargs)
 
         # Decide whether to normalize
-        if normed_height:
+        if normed_height and not normed_area:
             weights = np.ones_like(y)/float(len(y))
         else:
             weights = None


### PR DESCRIPTION
Solves #293.

Confirmed that the output is the same in all combinations of `normed_height` and `normed_area`, both before and after this change.

This is stupidly simple, so I'll merge tomorrow night if there are no comments.