### PR TITLE
Removed verbose argument from namedtuple creation.

### DIFF
--- a/FlowCal/mef.py
+++ b/FlowCal/mef.py
@@ -1208,7 +1208,7 @@ def get_transform_fxn(data_beads,
                   'statistic',
                   'selection',
                   'fitting']
-        MEFOutput = collections.namedtuple('MEFOutput', fields, verbose=False)
+        MEFOutput = collections.namedtuple('MEFOutput', fields)
         out = MEFOutput(mef_channels=mef_channels,
                         transform_fxn=transform_fxn,
                         clustering=clustering_res,


### PR DESCRIPTION
Fixes #301.

This fix seems to make FlowCal 1.2.0 compatible with Python 3.7 and Anaconda 2018.12.