### PR TITLE
mef_values argument can now be a list or list of lists.

### DIFF
--- a/FlowCal/mef.py
+++ b/FlowCal/mef.py
@@ -917,6 +917,8 @@ def get_transform_fxn(data_beads,
     else:
         mef_channels = [mef_channels]
         mef_values   = [mef_values]
+    # Transform mef_values to numpy array
+    mef_values = np.array(mef_values)
 
     # Ensure matching number of `mef_values` for all channels (this implies
     # that the calibration beads have the same number of subpopulations for


### PR DESCRIPTION
Solves #308 

Tested with the following script against the example files:

```python
import numpy as np
import matplotlib.pyplot as plt

import FlowCal

b = FlowCal.io.FCSData('FCFiles/Beads006.fcs')
b = FlowCal.transform.to_rfi(b)
b_g, __, c = FlowCal.gate.density2d(b,
                                    channels=['FSC', 'SSC'],
                                    gate_fraction=0.3,
                                    full_output=True)

mef_values = [0, 646, 1704, 4827, 15991, 47609, 135896, 273006]
mef_channels = 'FL1'

to_mef = FlowCal.mef.get_transform_fxn(b_g,
                                       mef_values=mef_values,
                                       mef_channels=mef_channels,
                                       clustering_channels=['FL1', 'FL3'],
                                       verbose=True,
                                       plot=True)

plt.show()

```

And the following combinations of `mef_values`/`mef_channels`:

```python
mef_values = [0, 646, 1704, 4827, 15991, 47609, 135896, 273006]
mef_channels = 'FL1'
```

```python
mef_values = np.array([0, 646, 1704, 4827, 15991, 47609, 135896, 273006])
mef_channels = 'FL1'
```

```python
mef_values = np.array([[0, 646, 1704, 4827, 15991, 47609, 135896, 273006], 
                       [0, 1301, 3260, 8681, 30542, 94737, 355044, 1041442]])
mef_channels = ['FL1', 'FL3']
```

```python
mef_values = [np.array([0, 646, 1704, 4827, 15991, 47609, 135896, 273006]), 
              np.array([0, 1301, 3260, 8681, 30542, 94737, 355044, 1041442])]
mef_channels = ['FL1', 'FL3']
```

```python
mef_values = [[0, 646, 1704, 4827, 15991, 47609, 135896, 273006], 
              [0, 1301, 3260, 8681, 30542, 94737, 355044, 1041442]]
mef_channels = ['FL1', 'FL3']
```

All cases were successful.

I'm also giving this 1 day for comments, since it is a single line change in code.