### PR TITLE
Locator tick fix in matplotlib >= 3.1.0

### DIFF
--- a/FlowCal/plot.py
+++ b/FlowCal/plot.py
@@ -605,6 +605,9 @@ class _LogicleLocator(matplotlib.ticker.Locator):
             # Subticks not requested
             ticklocs = major_ticklocs
 
+        # Remove ticks outside requested range
+        ticklocs = [t for t in ticklocs if (t >= vmin) and (t <= vmax)]
+
         return self.raise_if_exceeds(np.array(ticklocs))
 
 

--- a/FlowCal/plot.py
+++ b/FlowCal/plot.py
@@ -674,7 +674,12 @@ class _LogicleScale(matplotlib.scale.ScaleBase):
 
     def __init__(self, axis, **kwargs):
         # Run parent's constructor
-        matplotlib.scale.ScaleBase.__init__(self)
+        if packaging.version.parse(matplotlib.__version__) \
+                >= packaging.version.parse('3.1.0'):
+            matplotlib.scale.ScaleBase.__init__(self, axis)
+        else:
+            matplotlib.scale.ScaleBase.__init__(self)
+
         # Initialize and store logicle transform object
         self._transform = _LogicleTransform(**kwargs)
 


### PR DESCRIPTION
Fixes #314 

Tested with matplotlib 3.0.0 and 2.0.0 as well.

#311 should be merged before this.