### PR TITLE
Clean up unit tests

### DIFF
--- a/test/test_excel_ui.py
+++ b/test/test_excel_ui.py
@@ -9,7 +9,10 @@ import unittest
 
 import numpy as np
 import pandas as pd
-import pandas.util.testing as tm
+try:
+    import pandas.testing as tm       # for pandas >= 0.20.1
+except ImportError:
+    import pandas.util.testing as tm  # for pandas <= 0.19.2
 
 import FlowCal
 

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -7,6 +7,7 @@ import datetime
 import os
 import six
 import unittest
+import warnings
 try:
    import cPickle as pickle
 except ImportError:
@@ -401,12 +402,14 @@ class TestReadTextSegment(unittest.TestCase):
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v3'}
         buf              = six.BytesIO(six.b(raw_text_segment))
-        self.assertEqual(
-            FlowCal.io.read_fcs_text_segment(
-                buf=buf,
-                begin=0,
-                end=len(raw_text_segment)-1),
-            (text_dict, delim))
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', category=UserWarning)
+            self.assertEqual(
+                FlowCal.io.read_fcs_text_segment(
+                    buf=buf,
+                    begin=0,
+                    end=len(raw_text_segment)-1),
+                (text_dict, delim))
 
     def test_primary_multi_delim_in_keyword_1(self):
         """
@@ -1134,14 +1137,16 @@ class TestReadTextSegment(unittest.TestCase):
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v3'}
         buf              = six.BytesIO(six.b(raw_text_segment))
-        self.assertEqual(
-            FlowCal.io.read_fcs_text_segment(
-                buf=buf,
-                begin=0,
-                end=len(raw_text_segment)-1,
-                delim=delim,
-                supplemental=True),
-            (text_dict, delim))
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', category=UserWarning)
+            self.assertEqual(
+                FlowCal.io.read_fcs_text_segment(
+                    buf=buf,
+                    begin=0,
+                    end=len(raw_text_segment)-1,
+                    delim=delim,
+                    supplemental=True),
+                (text_dict, delim))
 
     def test_supp_bad_segment_s(self):
         """
@@ -1152,14 +1157,16 @@ class TestReadTextSegment(unittest.TestCase):
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v3'}
         buf              = six.BytesIO(six.b(raw_text_segment))
-        self.assertEqual(
-            FlowCal.io.read_fcs_text_segment(
-                buf=buf,
-                begin=0,
-                end=len(raw_text_segment)-1,
-                delim=delim,
-                supplemental=True),
-            (text_dict, delim))
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', category=UserWarning)
+            self.assertEqual(
+                FlowCal.io.read_fcs_text_segment(
+                    buf=buf,
+                    begin=0,
+                    end=len(raw_text_segment)-1,
+                    delim=delim,
+                    supplemental=True),
+                (text_dict, delim))
 
     def test_supp_multi_delim_in_keyword_1(self):
         """

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -414,6 +414,23 @@ class TestReadTextSegment(unittest.TestCase):
                     end=len(raw_text_segment)-1),
                 (text_dict, delim))
 
+    if six.PY3:
+        def test_primary_bad_segment_warning(self):
+            """
+            Test warning with unpaired non-boundary delimiter in last value.
+
+            """
+            raw_text_segment = '/k1/v1/k2/v2/k3/v3//'
+            delim            = '/'
+            text_dict        = {'k1':'v1','k2':'v2','k3':'v3'}
+            buf              = six.BytesIO(six.b(raw_text_segment))
+
+            with self.assertWarnsRegex(UserWarning,
+                                       'ill-formed TEXT segment'):
+                FlowCal.io.read_fcs_text_segment(buf=buf,
+                                                 begin=0,
+                                                 end=len(raw_text_segment)-1)
+
     def test_primary_multi_delim_in_keyword_1(self):
         """
         Test that multiple delimiters in keyword still parses correctly.
@@ -1154,6 +1171,25 @@ class TestReadTextSegment(unittest.TestCase):
                     supplemental=True),
                 (text_dict, delim))
 
+    if six.PY3:
+        def test_supp_bad_segment_warning(self):
+            """
+            Test warning with unpaired non-boundary delimiter in last value.
+
+            """
+            raw_text_segment = '/k1/v1/k2/v2/k3/v3//'
+            delim            = '/'
+            text_dict        = {'k1':'v1','k2':'v2','k3':'v3'}
+            buf              = six.BytesIO(six.b(raw_text_segment))
+
+            with self.assertWarnsRegex(UserWarning,
+                                       'ill-formed TEXT segment'):
+                FlowCal.io.read_fcs_text_segment(buf=buf,
+                                                 begin=0,
+                                                 end=len(raw_text_segment)-1,
+                                                 delim=delim,
+                                                 supplemental=True)
+
     def test_supp_bad_segment_s(self):
         """
         Test edge case with unpaired non-boundary delimiter in last value.
@@ -1176,6 +1212,25 @@ class TestReadTextSegment(unittest.TestCase):
                     delim=delim,
                     supplemental=True),
                 (text_dict, delim))
+
+    if six.PY3:
+        def test_supp_bad_segment_s_warning(self):
+            """
+            Test warning with unpaired non-boundary delimiter in last value.
+
+            """
+            raw_text_segment = 'k1/v1/k2/v2/k3/v3//'
+            delim            = '/'
+            text_dict        = {'k1':'v1','k2':'v2','k3':'v3'}
+            buf              = six.BytesIO(six.b(raw_text_segment))
+
+            with self.assertWarnsRegex(UserWarning,
+                                       'ill-formed TEXT segment'):
+                FlowCal.io.read_fcs_text_segment(buf=buf,
+                                                 begin=0,
+                                                 end=len(raw_text_segment)-1,
+                                                 delim=delim,
+                                                 supplemental=True)
 
     def test_supp_multi_delim_in_keyword_1(self):
         """

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -402,8 +402,11 @@ class TestReadTextSegment(unittest.TestCase):
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v3'}
         buf              = six.BytesIO(six.b(raw_text_segment))
+
+        # ignore an "ill-formed TEXT" UserWarning
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', category=UserWarning)
+
             self.assertEqual(
                 FlowCal.io.read_fcs_text_segment(
                     buf=buf,
@@ -1137,8 +1140,11 @@ class TestReadTextSegment(unittest.TestCase):
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v3'}
         buf              = six.BytesIO(six.b(raw_text_segment))
+
+        # ignore an "ill-formed TEXT" UserWarning
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', category=UserWarning)
+
             self.assertEqual(
                 FlowCal.io.read_fcs_text_segment(
                     buf=buf,
@@ -1157,8 +1163,11 @@ class TestReadTextSegment(unittest.TestCase):
         delim            = '/'
         text_dict        = {'k1':'v1','k2':'v2','k3':'v3'}
         buf              = six.BytesIO(six.b(raw_text_segment))
+
+        # ignore an "ill-formed TEXT" UserWarning
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', category=UserWarning)
+
             self.assertEqual(
                 FlowCal.io.read_fcs_text_segment(
                     buf=buf,

--- a/test/test_stats.py
+++ b/test/test_stats.py
@@ -4,7 +4,6 @@
 """
 
 import unittest
-import warnings
 
 import numpy as np
 import scipy
@@ -88,43 +87,24 @@ class TestGeometricMean(unittest.TestCase):
     """
     def setUp(self):
         # 10x2 array
-        self.a = np.array([[0, 8, 6, 1, 1, 6, 5, 9, 2, 2],
-                           [9, 9, 2, 0, 2, 0, 8, 8, 4, 7]]).T
+        self.a = np.array([[1, 8, 6, 1, 1, 6, 5, 9, 2, 2],
+                           [9, 9, 2, 1, 2, 1, 8, 8, 4, 7]]).T
         # FCSFile
         self.d = FlowCal.io.FCSData('test/Data001.fcs')
+        # Transform fluorescence data to a.u. so that there are no zeros
+        self.d = FlowCal.transform.to_rfi(
+            self.d,
+            channels=['FL1-H', 'FL2-H', 'FL3-H'])
 
     def test_array(self):
         """
         Test size, type, and values when using a 2D numpy array.
 
         """
-        # ignore divide-by-zero RuntimeWarnings that arise because
-        # the data array contains zeros.
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', category=RuntimeWarning)
-
-            s_fc = FlowCal.stats.gmean(self.a)
-            s_lib = scipy.stats.gmean(self.a, axis=0)
-
+        s_fc = FlowCal.stats.gmean(self.a)
+        s_lib = scipy.stats.gmean(self.a, axis=0)
         self.assertIsInstance(s_fc, type(s_lib))
         self.assertEqual(s_fc.shape, (2,))
-        np.testing.assert_array_equal(s_fc, s_lib)
-
-    def test_fcs_data(self):
-        """
-        Test size, type, and values when using an FCSData object.
-
-        """
-        # ignore divide-by-zero RuntimeWarnings that arise because
-        # the FCS data contains zeros in some channels.
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', category=RuntimeWarning)
-
-            s_fc = FlowCal.stats.gmean(self.d)
-            s_lib = scipy.stats.gmean(self.d.view(np.ndarray), axis=0)
-
-        self.assertIsInstance(s_fc, type(s_lib))
-        self.assertEqual(s_fc.shape, (6,))
         np.testing.assert_array_equal(s_fc, s_lib)
 
     def test_fcs_data_slice_1d(self):
@@ -132,14 +112,8 @@ class TestGeometricMean(unittest.TestCase):
         Test size, type, and values when using a 1D sliced FCSData object.
 
         """
-        # ignore divide-by-zero RuntimeWarnings that arise because
-        # the FCS data contains zeros in some channels.
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', category=RuntimeWarning)
-
-            s_fc = FlowCal.stats.gmean(self.d[:, 'FL1-H'])
-            s_lib = scipy.stats.gmean(self.d[:, 'FL1-H'].view(np.ndarray))
-
+        s_fc = FlowCal.stats.gmean(self.d[:, 'FL1-H'])
+        s_lib = scipy.stats.gmean(self.d[:, 'FL1-H'].view(np.ndarray))
         self.assertIsInstance(s_fc, type(s_lib))
         self.assertEqual(s_fc.shape, ())
         self.assertEqual(s_fc, s_lib)
@@ -150,14 +124,8 @@ class TestGeometricMean(unittest.TestCase):
         `channels` argument.
 
         """
-        # ignore divide-by-zero RuntimeWarnings that arise because
-        # the FCS data contains zeros in some channels.
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', category=RuntimeWarning)
-
-            s_fc = FlowCal.stats.gmean(self.d, channels='FL1-H')
-            s_lib = scipy.stats.gmean(self.d[:, 'FL1-H'].view(np.ndarray))
-
+        s_fc = FlowCal.stats.gmean(self.d, channels='FL1-H')
+        s_lib = scipy.stats.gmean(self.d[:, 'FL1-H'].view(np.ndarray))
         self.assertIsInstance(s_fc, type(s_lib))
         self.assertEqual(s_fc.shape, ())
         self.assertEqual(s_fc, s_lib)
@@ -168,14 +136,8 @@ class TestGeometricMean(unittest.TestCase):
         `channels` argument.
 
         """
-        # ignore divide-by-zero RuntimeWarnings that arise because
-        # the FCS data contains zeros in some channels.
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', category=RuntimeWarning)
-
-            s_fc = FlowCal.stats.gmean(self.d, channels=['FL1-H', 'FL2-H', 'FL3-H'])
-            s_lib = scipy.stats.gmean(self.d[:, [2, 3, 4]].view(np.ndarray), axis=0)
-
+        s_fc = FlowCal.stats.gmean(self.d, channels=['FL1-H', 'FL2-H', 'FL3-H'])
+        s_lib = scipy.stats.gmean(self.d[:, [2, 3, 4]].view(np.ndarray), axis=0)
         self.assertIsInstance(s_fc, type(s_lib))
         self.assertEqual(s_fc.shape, (3,))
         np.testing.assert_array_equal(s_fc, s_lib)
@@ -490,23 +452,6 @@ class TestGeomStd(unittest.TestCase):
         self.assertEqual(s_fc.shape, (2,))
         np.testing.assert_array_equal(s_fc, s_lib)
 
-    def test_fcs_data(self):
-        """
-        Test size, type, and values when using an FCSData object.
-
-        """
-        # ignore divide-by-zero RuntimeWarnings that arise because
-        # the FCS data contains zeros in some channels.
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', category=RuntimeWarning)
-
-            s_fc = FlowCal.stats.gstd(self.d)
-            s_lib = np.exp(np.std(np.log(self.d.view(np.ndarray)), axis=0))
-
-        self.assertIsInstance(s_fc, type(s_lib))
-        self.assertEqual(s_fc.shape, (6,))
-        np.testing.assert_array_equal(s_fc, s_lib)
-
     def test_fcs_data_slice_1d(self):
         """
         Test size, type, and values when using a 1D sliced FCSData object.
@@ -570,24 +515,6 @@ class TestGeomCv(unittest.TestCase):
         s_lib = np.sqrt(np.exp(np.std(np.log(self.a), axis=0)**2) - 1)
         self.assertIsInstance(s_fc, type(s_lib))
         self.assertEqual(s_fc.shape, (2,))
-        np.testing.assert_array_equal(s_fc, s_lib)
-
-    def test_fcs_data(self):
-        """
-        Test size, type, and values when using an FCSData object.
-
-        """
-        # ignore divide-by-zero RuntimeWarnings that arise because
-        # the FCS data contains zeros in some channels.
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', category=RuntimeWarning)
-
-            s_fc = FlowCal.stats.gcv(self.d)
-            s_lib = np.sqrt(np.exp(np.std(np.log(
-                self.d.view(np.ndarray)), axis=0)**2) - 1)
-
-        self.assertIsInstance(s_fc, type(s_lib))
-        self.assertEqual(s_fc.shape, (6,))
         np.testing.assert_array_equal(s_fc, s_lib)
 
     def test_fcs_data_slice_1d(self):

--- a/test/test_stats.py
+++ b/test/test_stats.py
@@ -4,6 +4,7 @@
 """
 
 import unittest
+import warnings
 
 import numpy as np
 import scipy
@@ -97,8 +98,14 @@ class TestGeometricMean(unittest.TestCase):
         Test size, type, and values when using a 2D numpy array.
 
         """
-        s_fc = FlowCal.stats.gmean(self.a)
-        s_lib = scipy.stats.gmean(self.a, axis=0)
+        # ignore divide-by-zero RuntimeWarnings that arise because
+        # the data array contains zeros.
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', category=RuntimeWarning)
+
+            s_fc = FlowCal.stats.gmean(self.a)
+            s_lib = scipy.stats.gmean(self.a, axis=0)
+
         self.assertIsInstance(s_fc, type(s_lib))
         self.assertEqual(s_fc.shape, (2,))
         np.testing.assert_array_equal(s_fc, s_lib)
@@ -108,8 +115,14 @@ class TestGeometricMean(unittest.TestCase):
         Test size, type, and values when using an FCSData object.
 
         """
-        s_fc = FlowCal.stats.gmean(self.d)
-        s_lib = scipy.stats.gmean(self.d.view(np.ndarray), axis=0)
+        # ignore divide-by-zero RuntimeWarnings that arise because
+        # the FCS data contains zeros in some channels.
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', category=RuntimeWarning)
+
+            s_fc = FlowCal.stats.gmean(self.d)
+            s_lib = scipy.stats.gmean(self.d.view(np.ndarray), axis=0)
+
         self.assertIsInstance(s_fc, type(s_lib))
         self.assertEqual(s_fc.shape, (6,))
         np.testing.assert_array_equal(s_fc, s_lib)
@@ -119,8 +132,14 @@ class TestGeometricMean(unittest.TestCase):
         Test size, type, and values when using a 1D sliced FCSData object.
 
         """
-        s_fc = FlowCal.stats.gmean(self.d[:, 'FL1-H'])
-        s_lib = scipy.stats.gmean(self.d[:, 'FL1-H'].view(np.ndarray))
+        # ignore divide-by-zero RuntimeWarnings that arise because
+        # the FCS data contains zeros in some channels.
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', category=RuntimeWarning)
+
+            s_fc = FlowCal.stats.gmean(self.d[:, 'FL1-H'])
+            s_lib = scipy.stats.gmean(self.d[:, 'FL1-H'].view(np.ndarray))
+
         self.assertIsInstance(s_fc, type(s_lib))
         self.assertEqual(s_fc.shape, ())
         self.assertEqual(s_fc, s_lib)
@@ -131,8 +150,14 @@ class TestGeometricMean(unittest.TestCase):
         `channels` argument.
 
         """
-        s_fc = FlowCal.stats.gmean(self.d, channels='FL1-H')
-        s_lib = scipy.stats.gmean(self.d[:, 'FL1-H'].view(np.ndarray))
+        # ignore divide-by-zero RuntimeWarnings that arise because
+        # the FCS data contains zeros in some channels.
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', category=RuntimeWarning)
+
+            s_fc = FlowCal.stats.gmean(self.d, channels='FL1-H')
+            s_lib = scipy.stats.gmean(self.d[:, 'FL1-H'].view(np.ndarray))
+
         self.assertIsInstance(s_fc, type(s_lib))
         self.assertEqual(s_fc.shape, ())
         self.assertEqual(s_fc, s_lib)
@@ -143,8 +168,14 @@ class TestGeometricMean(unittest.TestCase):
         `channels` argument.
 
         """
-        s_fc = FlowCal.stats.gmean(self.d, channels=['FL1-H', 'FL2-H', 'FL3-H'])
-        s_lib = scipy.stats.gmean(self.d[:, [2, 3, 4]].view(np.ndarray), axis=0)
+        # ignore divide-by-zero RuntimeWarnings that arise because
+        # the FCS data contains zeros in some channels.
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', category=RuntimeWarning)
+
+            s_fc = FlowCal.stats.gmean(self.d, channels=['FL1-H', 'FL2-H', 'FL3-H'])
+            s_lib = scipy.stats.gmean(self.d[:, [2, 3, 4]].view(np.ndarray), axis=0)
+
         self.assertIsInstance(s_fc, type(s_lib))
         self.assertEqual(s_fc.shape, (3,))
         np.testing.assert_array_equal(s_fc, s_lib)
@@ -464,8 +495,14 @@ class TestGeomStd(unittest.TestCase):
         Test size, type, and values when using an FCSData object.
 
         """
-        s_fc = FlowCal.stats.gstd(self.d)
-        s_lib = np.exp(np.std(np.log(self.d.view(np.ndarray)), axis=0))
+        # ignore divide-by-zero RuntimeWarnings that arise because
+        # the FCS data contains zeros in some channels.
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', category=RuntimeWarning)
+
+            s_fc = FlowCal.stats.gstd(self.d)
+            s_lib = np.exp(np.std(np.log(self.d.view(np.ndarray)), axis=0))
+
         self.assertIsInstance(s_fc, type(s_lib))
         self.assertEqual(s_fc.shape, (6,))
         np.testing.assert_array_equal(s_fc, s_lib)
@@ -540,9 +577,15 @@ class TestGeomCv(unittest.TestCase):
         Test size, type, and values when using an FCSData object.
 
         """
-        s_fc = FlowCal.stats.gcv(self.d)
-        s_lib = np.sqrt(np.exp(np.std(np.log(
-            self.d.view(np.ndarray)), axis=0)**2) - 1)
+        # ignore divide-by-zero RuntimeWarnings that arise because
+        # the FCS data contains zeros in some channels.
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', category=RuntimeWarning)
+
+            s_fc = FlowCal.stats.gcv(self.d)
+            s_lib = np.sqrt(np.exp(np.std(np.log(
+                self.d.view(np.ndarray)), axis=0)**2) - 1)
+
         self.assertIsInstance(s_fc, type(s_lib))
         self.assertEqual(s_fc.shape, (6,))
         np.testing.assert_array_equal(s_fc, s_lib)


### PR DESCRIPTION
FlowCal unit tests currently throw various warnings. This pull request resolves most of them.

Three sets of warnings were resolved:
1) "ill-formed TEXT" warnings correctly raised by FlowCal were ignored in the unit tests,
2) divide-by-zero warnings were ignored in the `test_stats.py` unit tests, and
3) the Excel UI was updated to address a `pandas` deprecation.

A fourth issue related to `panda`'s use of `xlrd` to read Excel files may require more substantial changes and will be addressed separately.

_NOTE:_ The divide-by-zero warnings largely arise because geometric statistics are calculated on FCS data containing zeros. However, some unit tests transform the FCS data to avoid this ([`TestGeomStd`](https://github.com/taborlab/FlowCal/blob/9cd83ef7fadf235e548bc6c1bb5ed22d4dde8416/test/test_stats.py#L435) and [`TestGeomCv`](https://github.com/taborlab/FlowCal/blob/9cd83ef7fadf235e548bc6c1bb5ed22d4dde8416/test/test_stats.py#L511)). I chose to suppress the warnings and maintain current test behavior, but a single strategy should probably be used. I naively favor transforming the FCS data of the offending tests instead of suppressing warnings, but I defer to @castillohair.

#### Behavior after pull request (bf493dbc0f9ca279f9190ec2373dd419756907f6):
Python 3.8, Anaconda 2020.02
```
>python -m unittest discover
C:\Users\sexto\AppData\Local\conda\conda\envs\py3_fc_anaconda2020.02\lib\site-packages\xlrd\xlsx.py:266: DeprecationWarning: This method will be removed in future versions.  Use 'tree.iter()' or 'list(tree.iter())' instead.
  for elem in self.tree.iter() if Element_has_iter else self.tree.getiterator():
C:\Users\sexto\AppData\Local\conda\conda\envs\py3_fc_anaconda2020.02\lib\site-packages\xlrd\xlsx.py:312: DeprecationWarning: This method will be removed in future versions.  Use 'tree.iter()' or 'list(tree.iter())' instead.
  for elem in self.tree.iter() if Element_has_iter else self.tree.getiterator():
.............................................................................................................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 365 tests in 2.783s

OK
```
Python 3.8, vanilla (no Anaconda); Python 2.7, Anaconda 2019.10; Python 2.7, vanilla (no Anaconda); Python 2.7, Anaconda 4.3.0 (oldest supported)
```
>python -m unittest discover
.............................................................................................................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 365 tests in 2.637s

OK
```

#### Previous behavior:
Python 3.8, Anaconda 2020.02
```
>python -m unittest discover
C:\Users\sexto\Downloads\FlowCal\test\test_excel_ui.py:12: FutureWarning: pandas.util.testing is deprecated. Use the functions in the public API at pandas.testing instead.
  import pandas.util.testing as tm
C:\Users\sexto\AppData\Local\conda\conda\envs\py3_fc_anaconda2020.02\lib\site-packages\xlrd\xlsx.py:266: DeprecationWarning: This method will be removed in future versions.  Use 'tree.iter()' or 'list(tree.iter())' instead.
  for elem in self.tree.iter() if Element_has_iter else self.tree.getiterator():
C:\Users\sexto\AppData\Local\conda\conda\envs\py3_fc_anaconda2020.02\lib\site-packages\xlrd\xlsx.py:312: DeprecationWarning: This method will be removed in future versions.  Use 'tree.iter()' or 'list(tree.iter())' instead.
  for elem in self.tree.iter() if Element_has_iter else self.tree.getiterator():
...........................................................................................................................................................................................C:\Users\sexto\Downloads\FlowCal\FlowCal\io.py:330: UserWarning: detected ill-formed TEXT segment (ends with two delimiter characters). Ignoring last delimiter character
  warnings.warn("detected ill-formed TEXT segment (ends"
...................................................................................C:\Users\sexto\Downloads\FlowCal\FlowCal\stats.py:246: RuntimeWarning: divide by zero encountered in log
  return np.sqrt(np.exp(np.std(np.log(data_stats), axis=0)**2) - 1)
C:\Users\sexto\AppData\Local\conda\conda\envs\py3_fc_anaconda2020.02\lib\site-packages\numpy\core\_methods.py:193: RuntimeWarning: invalid value encountered in subtract
  x = asanyarray(arr - arrmean)
C:\Users\sexto\Downloads\FlowCal\test\test_stats.py:544: RuntimeWarning: divide by zero encountered in log
  s_lib = np.sqrt(np.exp(np.std(np.log(
.....C:\Users\sexto\Downloads\FlowCal\FlowCal\stats.py:217: RuntimeWarning: divide by zero encountered in log
  return np.exp(np.std(np.log(data_stats), axis=0))
C:\Users\sexto\Downloads\FlowCal\test\test_stats.py:468: RuntimeWarning: divide by zero encountered in log
  s_lib = np.exp(np.std(np.log(self.d.view(np.ndarray)), axis=0))
....C:\Users\sexto\AppData\Local\conda\conda\envs\py3_fc_anaconda2020.02\lib\site-packages\scipy\stats\stats.py:338: RuntimeWarning: divide by zero encountered in log
  log_a = np.log(a)
......................................................................................
----------------------------------------------------------------------
Ran 365 tests in 2.908s

OK
```
Python 3.8, vanilla (no Anaconda)
```
>python -m unittest discover
C:\Users\sexto\Downloads\FlowCal\test\test_excel_ui.py:12: FutureWarning: pandas.util.testing is deprecated. Use the functions in the public API at pandas.testing instead.
  import pandas.util.testing as tm
...........................................................................................................................................................................................C:\Users\sexto\Downloads\FlowCal\FlowCal\io.py:330: UserWarning: detected ill-formed TEXT segment (ends with two delimiter characters). Ignoring last delimiter character
  warnings.warn("detected ill-formed TEXT segment (ends"
...................................................................................C:\Users\sexto\Downloads\FlowCal\FlowCal\stats.py:246: RuntimeWarning: divide by zero encountered in log
  return np.sqrt(np.exp(np.std(np.log(data_stats), axis=0)**2) - 1)
C:\Users\sexto\AppData\Local\conda\conda\envs\py3_fc_vanilla\lib\site-packages\numpy\core\_methods.py:193: RuntimeWarning: invalid value encountered in subtract
  x = asanyarray(arr - arrmean)
C:\Users\sexto\Downloads\FlowCal\test\test_stats.py:544: RuntimeWarning: divide by zero encountered in log
  s_lib = np.sqrt(np.exp(np.std(np.log(
.....C:\Users\sexto\Downloads\FlowCal\FlowCal\stats.py:217: RuntimeWarning: divide by zero encountered in log
  return np.exp(np.std(np.log(data_stats), axis=0))
C:\Users\sexto\Downloads\FlowCal\test\test_stats.py:468: RuntimeWarning: divide by zero encountered in log
  s_lib = np.exp(np.std(np.log(self.d.view(np.ndarray)), axis=0))
....C:\Users\sexto\AppData\Local\conda\conda\envs\py3_fc_vanilla\lib\site-packages\scipy\stats\stats.py:338: RuntimeWarning: divide by zero encountered in log
  log_a = np.log(a)
......................................................................................
----------------------------------------------------------------------
Ran 365 tests in 2.714s

OK
```
Python 2.7, Anaconda 2019.10
```
>python -m unittest discover
...........................................................................................................................................................................................C:\Users\sexto\Downloads\FlowCal\FlowCal\io.py:332: UserWarning: detected ill-formed TEXT segment (ends with two delimiter characters). Ignoring last delimiter character
  + " Ignoring last delimiter character")
...................................................................................C:\Users\sexto\Downloads\FlowCal\FlowCal\stats.py:246: RuntimeWarning: divide by zero encountered in log
  return np.sqrt(np.exp(np.std(np.log(data_stats), axis=0)**2) - 1)
C:\Users\sexto\AppData\Local\conda\conda\envs\py2_fc_anaconda2019.10\lib\site-packages\numpy\core\_methods.py:117: RuntimeWarning: invalid value encountered in subtract
  x = asanyarray(arr - arrmean)
C:\Users\sexto\Downloads\FlowCal\test\test_stats.py:545: RuntimeWarning: divide by zero encountered in log
  self.d.view(np.ndarray)), axis=0)**2) - 1)
.....C:\Users\sexto\Downloads\FlowCal\FlowCal\stats.py:217: RuntimeWarning: divide by zero encountered in log
  return np.exp(np.std(np.log(data_stats), axis=0))
C:\Users\sexto\Downloads\FlowCal\test\test_stats.py:468: RuntimeWarning: divide by zero encountered in log
  s_lib = np.exp(np.std(np.log(self.d.view(np.ndarray)), axis=0))
....C:\Users\sexto\AppData\Local\conda\conda\envs\py2_fc_anaconda2019.10\lib\site-packages\scipy\stats\stats.py:316: RuntimeWarning: divide by zero encountered in log
  log_a = np.log(a)
......................................................................................
----------------------------------------------------------------------
Ran 365 tests in 3.733s

OK
```
Python 2.7, vanilla (no Anaconda)
```
>python -m unittest discover
...........................................................................................................................................................................................C:\Users\sexto\Downloads\FlowCal\FlowCal\io.py:332: UserWarning: detected ill-formed TEXT segment (ends with two delimiter characters). Ignoring last delimiter character
  + " Ignoring last delimiter character")
...................................................................................C:\Users\sexto\Downloads\FlowCal\FlowCal\stats.py:246: RuntimeWarning: divide by zero encountered in log
  return np.sqrt(np.exp(np.std(np.log(data_stats), axis=0)**2) - 1)
C:\Users\sexto\AppData\Local\conda\conda\envs\py2_fc_vanilla\lib\site-packages\numpy\core\_methods.py:117: RuntimeWarning: invalid value encountered in subtract
  x = asanyarray(arr - arrmean)
C:\Users\sexto\Downloads\FlowCal\test\test_stats.py:545: RuntimeWarning: divide by zero encountered in log
  self.d.view(np.ndarray)), axis=0)**2) - 1)
.....C:\Users\sexto\Downloads\FlowCal\FlowCal\stats.py:217: RuntimeWarning: divide by zero encountered in log
  return np.exp(np.std(np.log(data_stats), axis=0))
C:\Users\sexto\Downloads\FlowCal\test\test_stats.py:468: RuntimeWarning: divide by zero encountered in log
  s_lib = np.exp(np.std(np.log(self.d.view(np.ndarray)), axis=0))
....C:\Users\sexto\AppData\Local\conda\conda\envs\py2_fc_vanilla\lib\site-packages\scipy\stats\stats.py:316: RuntimeWarning: divide by zero encountered in log
  log_a = np.log(a)
......................................................................................
----------------------------------------------------------------------
Ran 365 tests in 3.574s

OK
```
Python 2.7, Anaconda 4.3.0 (oldest supported)
```
>python -m unittest discover
...........................................................................................................................................................................................C:\Users\sexto\Downloads\FlowCal\FlowCal\io.py:332: UserWarning: detected ill-formed TEXT segment (ends with two delimiter characters). Ignoring last delimiter character
  + " Ignoring last delimiter character")
...................................................................................C:\Users\sexto\Downloads\FlowCal\FlowCal\stats.py:246: RuntimeWarning: divide by zero encountered in log
  return np.sqrt(np.exp(np.std(np.log(data_stats), axis=0)**2) - 1)
C:\Users\sexto\AppData\Local\conda\conda\envs\py2_fc_anaconda4.3.0\lib\site-packages\numpy\core\_methods.py:101: RuntimeWarning: invalid value encountered in subtract
  x = asanyarray(arr - arrmean)
C:\Users\sexto\Downloads\FlowCal\test\test_stats.py:545: RuntimeWarning: divide by zero encountered in log
  self.d.view(np.ndarray)), axis=0)**2) - 1)
.....C:\Users\sexto\Downloads\FlowCal\FlowCal\stats.py:217: RuntimeWarning: divide by zero encountered in log
  return np.exp(np.std(np.log(data_stats), axis=0))
C:\Users\sexto\Downloads\FlowCal\test\test_stats.py:468: RuntimeWarning: divide by zero encountered in log
  s_lib = np.exp(np.std(np.log(self.d.view(np.ndarray)), axis=0))
....C:\Users\sexto\AppData\Local\conda\conda\envs\py2_fc_anaconda4.3.0\lib\site-packages\scipy\stats\stats.py:314: RuntimeWarning: divide by zero encountered in log
  log_a = np.log(a)
......................................................................................
----------------------------------------------------------------------
Ran 365 tests in 4.669s

OK
```