### PR TITLE
Remove palettable

### DIFF
--- a/FlowCal/mef.py
+++ b/FlowCal/mef.py
@@ -24,7 +24,7 @@ import FlowCal.plot
 import FlowCal.transform
 import FlowCal.stats
 
-standard_curve_colors = ['b', 'g', 'r']
+standard_curve_colors = ['tab:blue', 'tab:green', 'tab:orange']
 
 def clustering_gmm(data,
                    n_clusters,

--- a/FlowCal/mef.py
+++ b/FlowCal/mef.py
@@ -24,14 +24,7 @@ import FlowCal.plot
 import FlowCal.transform
 import FlowCal.stats
 
-# Use default colors from palettable if available
-try:
-    import palettable
-except ImportError as e:
-    standard_curve_colors = ['b', 'g', 'r']
-else:
-    standard_curve_colors = \
-        palettable.colorbrewer.qualitative.Paired_12.mpl_colors[1::2]
+standard_curve_colors = ['b', 'g', 'r']
 
 def clustering_gmm(data,
                    n_clusters,

--- a/FlowCal/mef.py
+++ b/FlowCal/mef.py
@@ -24,7 +24,7 @@ import FlowCal.plot
 import FlowCal.transform
 import FlowCal.stats
 
-standard_curve_colors = ['tab:blue', 'tab:green', 'tab:orange']
+standard_curve_colors = ['tab:blue', 'tab:green', 'tab:red']
 
 def clustering_gmm(data,
                    n_clusters,

--- a/FlowCal/plot.py
+++ b/FlowCal/plot.py
@@ -58,7 +58,7 @@ from mpl_toolkits.mplot3d import Axes3D
 from matplotlib.font_manager import FontProperties
 import warnings
 
-cmap_default = plt.get_cmap(matplotlib.rcParams['image.cmap'])
+cmap_default = plt.get_cmap('Spectral_r')
 
 savefig_dpi = 250
 

--- a/FlowCal/plot.py
+++ b/FlowCal/plot.py
@@ -58,13 +58,7 @@ from mpl_toolkits.mplot3d import Axes3D
 from matplotlib.font_manager import FontProperties
 import warnings
 
-# Use default colors from palettable if available
-try:
-    import palettable
-except ImportError as e:
-    cmap_default = plt.get_cmap(matplotlib.rcParams['image.cmap'])
-else:
-    cmap_default = palettable.colorbrewer.diverging.Spectral_8_r.mpl_colormap
+cmap_default = plt.get_cmap(matplotlib.rcParams['image.cmap'])
 
 savefig_dpi = 250
 

--- a/FlowCal/plot.py
+++ b/FlowCal/plot.py
@@ -1780,7 +1780,8 @@ def density_and_hist(data,
 
     # Colors
     n_colors = n_plots - 1
-    colors = [cmap_default(i) for i in np.linspace(0, 1, n_colors)]
+    default_property_cycler = plt.rcParams['axes.prop_cycle']()
+    colors = [next(default_property_cycler)['color'] for i in range(n_colors)]
     # Histogram
     for i, hist_channel in enumerate(hist_channels):
         # Define subplot

--- a/doc/getting_started/install_python.rst
+++ b/doc/getting_started/install_python.rst
@@ -14,7 +14,6 @@ Alternatively, download ``FlowCal`` from `here <https://github.com/taborlab/Flow
 * ``numpy`` (>=1.8.2)
 * ``scipy`` (>=0.14.0)
 * ``matplotlib`` (>=2.0.0)
-* ``palettable`` (>=2.1.1)
 * ``scikit-image`` (>=0.10.0)
 * ``scikit-learn`` (>=0.16.0)
 * ``pandas`` (>=0.16.1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ six>=1.10.0
 numpy>=1.8.2
 scipy>=0.14.0
 matplotlib>=2.0.0
-palettable>=2.1.1
 scikit-image>=0.10.0
 scikit-learn>=0.16.0
 pandas>=0.16.1

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,6 @@ setup(
                       'numpy>=1.8.2',
                       'scipy>=0.14.0',
                       'matplotlib>=2.0.0',
-                      'palettable>=2.1.1',
                       'scikit-image>=0.10.0',
                       'scikit-learn>=0.16.0',
                       'pandas>=0.16.1',


### PR DESCRIPTION
Remove dependency on `palettable` and replace it with similar alternatives from `matplotlib`. Closes https://github.com/taborlab/FlowCal/issues/181.

Comparison of plots produced by `>python -m FlowCal.excel_ui -p -i ./examples/experiment.xlsx`:
| Before pull request (9cd83ef7fadf235e548bc6c1bb5ed22d4dde8416) | After pull request (e44e9c8ef59b04f5a45646c0e6b897426224d241)|
|:----------------------:|:--------------------:|
| <img src="https://user-images.githubusercontent.com/2179825/81236376-ae5d5100-8fc2-11ea-8310-9b25a157b6a4.png" width="300" height="200" /> | <img src="https://user-images.githubusercontent.com/2179825/81237013-18c2c100-8fc4-11ea-9b7f-f4d892f57fff.png" width="300" height="200" /> |
| <img src="https://user-images.githubusercontent.com/2179825/81236433-d482f100-8fc2-11ea-96bf-65f746af00a5.png" width="300" height="400" /> | <img src="https://user-images.githubusercontent.com/2179825/81237029-26784680-8fc4-11ea-97b1-39e6ca3e10c7.png" width="300" height="400" /> |
| <img src="https://user-images.githubusercontent.com/2179825/81236539-0b590700-8fc3-11ea-9fde-2c3866d9a620.png" width="300" height="200" /> | <img src="https://user-images.githubusercontent.com/2179825/81237045-3001ae80-8fc4-11ea-9627-b075dbf05ff6.png" width="300" height="200" /> |
| <img src="https://user-images.githubusercontent.com/2179825/81236573-1b70e680-8fc3-11ea-8f9e-3e1cac5e2d79.png" width="300" height="200" /> | <img src="https://user-images.githubusercontent.com/2179825/81237063-38f28000-8fc4-11ea-802e-229417c87cfa.png" width="300" height="200" /> |
| <img src="https://user-images.githubusercontent.com/2179825/81236830-b5389380-8fc3-11ea-9651-24341ed115e5.png" width="300" height="300" /> | <img src="https://user-images.githubusercontent.com/2179825/81237080-44de4200-8fc4-11ea-8e79-6d1b1b4f29dc.png" width="300" height="300" /> |

I.e. blue now looks purple, but otherwise it's similar.