### PR TITLE
Correct scipy minimum requirement

### DIFF
--- a/doc/getting_started/install_python.rst
+++ b/doc/getting_started/install_python.rst
@@ -12,7 +12,7 @@ Alternatively, download ``FlowCal`` from `here <https://github.com/taborlab/Flow
 * ``packaging`` (>=16.8)
 * ``six`` (>=1.10.0)
 * ``numpy`` (>=1.8.2)
-* ``scipy`` (>=0.14.0)
+* ``scipy`` (>=0.19.0)
 * ``matplotlib`` (>=2.0.0)
 * ``palettable`` (>=2.1.1)
 * ``scikit-image`` (>=0.10.0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 packaging>=16.8
 six>=1.10.0
 numpy>=1.8.2
-scipy>=0.14.0
+scipy>=0.19.0
 matplotlib>=2.0.0
 palettable>=2.1.1
 scikit-image>=0.10.0

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
     install_requires=['packaging>=16.8',
                       'six>=1.10.0',
                       'numpy>=1.8.2',
-                      'scipy>=0.14.0',
+                      'scipy>=0.19.0',
                       'matplotlib>=2.0.0',
                       'palettable>=2.1.1',
                       'scikit-image>=0.10.0',


### PR DESCRIPTION
`mef.clustering_gmm` uses the `assume_a` parameter of `scipy.linalg.solve`, which was not introduced until `scipy` version 0.19.0. Make `scipy` v0.19.0 the minimum requirement for FlowCal.

This means Anaconda v4.4.0 is the lowest Anaconda version compliant with FlowCal's requirements.

Closes https://github.com/taborlab/FlowCal/issues/327.