### PR TITLE
Coerce mef.get_transform_fxn input to permit None values

### DIFF
--- a/FlowCal/mef.py
+++ b/FlowCal/mef.py
@@ -581,7 +581,8 @@ def get_transform_fxn(data_beads,
         Known MEF values for the calibration bead subpopulations, for each
         channel specified in `mef_channels`. The innermost sequences must
         have the same length (the same number of bead subpopulations must
-        exist for each channel).
+        exist for each channel). Values of np.nan or None specify that a
+        subpopulation should be omitted from the fitting procedure.
     mef_channels : int, or str, or list of int, or list of str
         Channels for which to generate transformation functions.
     verbose : bool, optional
@@ -917,18 +918,9 @@ def get_transform_fxn(data_beads,
     else:
         mef_channels = [mef_channels]
         mef_values   = [mef_values]
-    # Transform mef_values to numpy array
-    mef_values = np.array(mef_values)
 
-    # Ensure matching number of `mef_values` for all channels (this implies
-    # that the calibration beads have the same number of subpopulations for
-    # all channels).
-    if not np.all([len(mef_values_channel)==len(mef_values[0])
-                   for mef_values_channel in mef_values]):
-        msg  = "innermost sequences of mef_values must have the same length"
-        msg += " (same number of bead subpopulations must exist for each"
-        msg += " channel)"
-        raise ValueError(msg)
+    # Transform mef_values to numpy array
+    mef_values = np.array(mef_values, dtype=np.float)
 
     ###
     # 1. Clustering


### PR DESCRIPTION
Coerce `mef_values` input to `mef.get_transform_fxn()` to be a numpy array of floats. This coercion converts `None` values to `np.nan`, thereby permitting `None` as a synonym for `np.nan`. The coercion also eliminated the need for some type checking, as numpy now throws an error if the inner arrays don't have the same length.

Closes https://github.com/taborlab/FlowCal/issues/214.

All unit tests pass before (9cd83ef7fadf235e548bc6c1bb5ed22d4dde8416) and after (7be7ffa33bbd303f1d6a3daadb1280737c36beee) the change in `Python 3.8 + Anaconda 2020.02` and `Python 2.7 + Anaconda 4.4.0`.

The following code failed previously at the last line and is fixed by the change:

```python
import numpy as np
import FlowCal as fc
beads_sample = fc.io.FCSData('./examples/FCFiles/Beads006.fcs')
beads_sample = fc.transform.to_rfi(beads_sample, ['FSC','SSC','FL1','FL2','FL3'])
beads_sample = fc.gate.start_end(beads_sample, 250, 100)
beads_sample = fc.gate.high_low(beads_sample, channels=['FSC','SSC'])
beads_sample = fc.gate.density2d(data=beads_sample, channels=['FSC','SSC'], gate_fraction=0.85, xscale='logicle', yscale='logicle', sigma=5.)

mef_values   = [0, 646, 1704, 4827, 15991, 47609, 135896, 273006]
mef_output   = fc.mef.get_transform_fxn(beads_sample, mef_values, mef_channels='FL1', clustering_channels=['FL1', 'FL3'], plot=False)

mef_values   = [0, 646, 1704, 4827, 15991, 47609, 135896, np.nan]
mef_output   = fc.mef.get_transform_fxn(beads_sample, mef_values, mef_channels='FL1', clustering_channels=['FL1', 'FL3'], plot=False)

mef_values   = [0, 646, 1704, 4827, 15991, 47609, 135896, None]
mef_output   = fc.mef.get_transform_fxn(beads_sample, mef_values, mef_channels='FL1', clustering_channels=['FL1', 'FL3'], plot=False)
```

_NOTE:_ I first tried using `pd.isnull` [in place of `np.isnan`](https://github.com/taborlab/FlowCal/blob/9cd83ef7fadf235e548bc6c1bb5ed22d4dde8416/FlowCal/mef.py#L1066), but `fit_beads_autofluorescence()` would fail later [in `err_fun()`](https://github.com/taborlab/FlowCal/blob/9cd83ef7fadf235e548bc6c1bb5ed22d4dde8416/FlowCal/mef.py#L449). `pd.isnull` checks for other null types (like `None`) in addition to `np.nan`. I think the failure occurred because `mef_values=[0,...,None]` later [yields an object array](https://github.com/taborlab/FlowCal/blob/9cd83ef7fadf235e548bc6c1bb5ed22d4dde8416/FlowCal/mef.py#L921) instead of a numerical array. As such, I decided to just ensure `mef_values` was a numerical (`float`) array from the outset.