### PR TITLE
Refactored plot.hist1d to permit `weights` kwarg.

### DIFF
--- a/FlowCal/plot.py
+++ b/FlowCal/plot.py
@@ -941,67 +941,59 @@ def hist1d(data_list,
 
     # Iterate through data_list
     for i, data in enumerate(data_list):
+        hist_kwargs = kwargs.copy()  # note: this is a shallow copy
+
         # Extract channel
+        if 'x' in hist_kwargs:
+            raise ValueError("`x` must be specified via `data_list`")
         if data.ndim > 1:
-            y = data[:, channel]
+            hist_kwargs['x'] = data[:, channel]
         else:
-            y = data
+            hist_kwargs['x'] = data
 
         # If ``data_plot.hist_bins()`` exists, obtain bin edges from it if
         # necessary. If it does not exist, do not modify ``bins``.
-        if hasattr(y, 'hist_bins') and hasattr(y.hist_bins, '__call__'):
+        hist_kwargs['bins'] = bins
+        if hasattr(hist_kwargs['x'], 'hist_bins') \
+                and hasattr(hist_kwargs['x'].hist_bins, '__call__'):
             # If bins is None or an integer, get bin edges from
             # ``data_plot.hist_bins()``.
-            if bins is None or isinstance(bins, int):
-                bins = y.hist_bins(channels=0,
-                                   nbins=bins,
-                                   scale=xscale,
-                                   **xscale_kwargs)
+            if hist_kwargs['bins'] is None \
+                    or isinstance(hist_kwargs['bins'], int):
+                hist_kwargs['bins'] = hist_kwargs['x'].hist_bins(
+                    channels=0,
+                    nbins=hist_kwargs['bins'],
+                    scale=xscale,
+                    **xscale_kwargs)
 
-        # Decide whether to normalize
-        if normed_height and not normed_area:
-            weights = np.ones_like(y)/float(len(y))
-        else:
-            weights = None
-
-        # Actually plot
+        # Resolve normalizations
+        if 'density' in hist_kwargs:
+            msg  = "use `normed_area` instead of `density`"
+            raise ValueError(msg)
+        if 'normed' in hist_kwargs:
+            msg  = "use `normed_area` or `normed_height` instead of `normed`"
+            raise ValueError(msg)
         if packaging.version.parse(matplotlib.__version__) \
                 >= packaging.version.parse('2.2'):
-            if bins is not None:
-                n, edges, patches = plt.hist(y,
-                                             bins,
-                                             weights=weights,
-                                             density=normed_area,
-                                             histtype=histtype,
-                                             edgecolor=edgecolor[i],
-                                             facecolor=facecolor[i],
-                                             **kwargs)
-            else:
-                n, edges, patches = plt.hist(y,
-                                             weights=weights,
-                                             density=normed_area,
-                                             histtype=histtype,
-                                             edgecolor=edgecolor[i],
-                                             facecolor=facecolor[i],
-                                             **kwargs)
+            hist_kwargs['density'] = normed_area
         else:
-            if bins is not None:
-                n, edges, patches = plt.hist(y,
-                                             bins,
-                                             weights=weights,
-                                             normed=normed_area,
-                                             histtype=histtype,
-                                             edgecolor=edgecolor[i],
-                                             facecolor=facecolor[i],
-                                             **kwargs)
-            else:
-                n, edges, patches = plt.hist(y,
-                                             weights=weights,
-                                             normed=normed_area,
-                                             histtype=histtype,
-                                             edgecolor=edgecolor[i],
-                                             facecolor=facecolor[i],
-                                             **kwargs)
+            hist_kwargs['normed'] = normed_area
+
+        # Calculate weights if normalizing bins by height
+        if normed_height and not normed_area:
+            if 'weights' in hist_kwargs:
+                msg  = "`weights` must not be specified if"
+                msg += " `normed_height=True`"
+                raise ValueError(msg)
+            hist_kwargs['weights'] = np.ones_like(hist_kwargs['x'])
+            hist_kwargs['weights'] /= float(len(hist_kwargs['x']))
+
+        hist_kwargs['histtype']  = histtype
+        hist_kwargs['facecolor'] = facecolor[i]
+        hist_kwargs['edgecolor'] = edgecolor[i]
+
+        # Plot
+        n, edges, patches = plt.hist(**hist_kwargs)
 
     # Set scale of x axis
     if xscale=='logicle':
@@ -1017,9 +1009,9 @@ def hist1d(data_list,
     if xlabel is not None:
         # Highest priority is user-provided label
         plt.xlabel(xlabel)
-    elif hasattr(y, 'channels'):
+    elif hasattr(hist_kwargs['x'], 'channels'):
         # Attempt to use channel name
-        plt.xlabel(y.channels[0])
+        plt.xlabel(hist_kwargs['x'].channels[0])
 
     if ylabel is not None:
         # Highest priority is user-provided label


### PR DESCRIPTION
`plot.hist1d()` called with the `weights` parameter fails:
```
>>> FlowCal.plot.hist1d(np.array([1,2,3,1,2,1]), weights=[1,2,1,2,2,1])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\sexto\Downloads\FlowCal\FlowCal\plot.py", line 971, in hist1d
    n, edges, patches = plt.hist(y,
TypeError: hist() got multiple values for keyword argument 'weights'
```
I refactored `plot.hist1d()` to more precisely specify arguments to `plt.hist()`. Closes https://github.com/taborlab/FlowCal/issues/255.

All unit tests pass in `Python 3.8 + Anaconda 2020.02` and `Python 2.7 + Anaconda 4.4.0`.

After the change, the error shown above no longer occurs. `> python -m FlowCal.excel_ui -v -p -i ./examples/experiment.xlsx` also executes without error in both `Python 3.8 + Anaconda 2020.02` and `Python 2.7 + Anaconda 4.4.0`.