### PR TITLE
Change excel_ui functions to output OrderedDicts

### DIFF
--- a/doc/python_tutorial/excel_ui.rst
+++ b/doc/python_tutorial/excel_ui.rst
@@ -51,7 +51,7 @@ From there, one can obtain the file name and analysis options of each beads file
 ...     verbose=True,
 ...     plot=True)
 
-``FlowCal.excel_ui.process_beads_table`` uses the instruments table and the beads table to automatically open, density-gate, and transform the specified beads files, and generate MEF transformation functions as indicated by the Excel input file. The flags ``verbose`` and ``plot`` instruct the function to generate messages for each file being processed, and plots for each step of standard curve calculation, similar to what we saw in the :doc:`MEF tutorial </python_tutorial/mef>`. The ouput arguments are ``beads_samples``, a list of transformed and gated FCSData objects, and ``mef_transform_fxns``, a dictionary of MEF transformation functions, indexed by the ID of the beads files.
+``FlowCal.excel_ui.process_beads_table`` uses the instruments table and the beads table to automatically open, density-gate, and transform the specified beads files, and generate MEF transformation functions as indicated by the Excel input file. The flags ``verbose`` and ``plot`` instruct the function to generate messages for each file being processed, and plots for each step of standard curve calculation, similar to what we saw in the :doc:`MEF tutorial </python_tutorial/mef>`. The output arguments are ``beads_samples``, a dictionary of transformed and gated FCSData objects, and ``mef_transform_fxns``, a dictionary of MEF transformation functions, each indexed by the ID of the beads files.
 
 In a similar way, ``FlowCal``'s Excel UI can automatically density-gate and transform cell samples using a single instruction:
 
@@ -62,6 +62,6 @@ In a similar way, ``FlowCal``'s Excel UI can automatically density-gate and tran
 ...     verbose=True,
 ...     plot=True)
 
-``FlowCal.excel_ui.process_samples_table`` uses the instruments and samples tables to open, density-gate, and transform cell samples as specified, and return the processed data as a list of FCSData objects. If the input Excel file specifies that some samples should be transformed to MEF, ``FlowCal.excel_ui.process_samples_table`` also requires a dictionary with the respective MEF transformation functions (``mef_transform_fxns``), which was provided in the previous step by ``FlowCal.excel_ui.process_beads_table``.
+``FlowCal.excel_ui.process_samples_table`` uses the instruments and samples tables to open, density-gate, and transform cell samples as specified, and return the processed data as a dictionary of FCSData objects. If the input Excel file specifies that some samples should be transformed to MEF, ``FlowCal.excel_ui.process_samples_table`` also requires a dictionary with the respective MEF transformation functions (``mef_transform_fxns``), which was provided in the previous step by ``FlowCal.excel_ui.process_beads_table``.
 
 **This is all the code required to obtain a set of processed cell samples**. From here, one can perform any desired analysis on ``samples``. Note that ``samples_table`` contains any other information in the input Excel file not directly used by ``FlowCal``, such as inducer concentration, incubation time, etc. This can be used to build an induction curve, fluorescence vs. final optical density (OD), etc.

--- a/examples/analyze_excel_ui.py
+++ b/examples/analyze_excel_ui.py
@@ -50,10 +50,11 @@ if __name__ == "__main__":
     # To do so, it requires a table describing the flow cytometer used
     # (``instruments_table``). Here, we also use verbose mode, and indicate that
     # plots describing individual steps should be generated in the folder
-    # "plot_beads". The result is a list of ``FCSData`` objects representing
-    # gated and transformed calibration beads samples (``beads_samples``), and
-    # a dictionary containing MEF transformation functions
-    # (``mef_transform_fxns``). This will be used later to process cell samples.
+    # "plot_beads". The result is a dictionary of ``FCSData`` objects
+    # representing gated and transformed calibration beads samples
+    # (``beads_samples``), and a dictionary containing MEF transformation
+    # functions (``mef_transform_fxns``). This will be used later to process
+    # cell samples.
     beads_samples, mef_transform_fxns = FlowCal.excel_ui.process_beads_table(
         beads_table=beads_table,
         instruments_table=instruments_table,
@@ -98,7 +99,7 @@ if __name__ == "__main__":
     # in the context of accessory matplotlib functions to modify the axes
     # limits and labels and add a legend, among others.
     plt.figure(figsize=(6,3.5))
-    FlowCal.plot.hist1d(samples,
+    FlowCal.plot.hist1d(list(samples.values()),
                         channel='FL1',
                         histtype='step',
                         bins=128)
@@ -118,7 +119,7 @@ if __name__ == "__main__":
     # geometric mean from channel FL1 of each sample, and plot them against the
     # corresponding IPTG concentrations.
     samples_fluorescence = [FlowCal.stats.gmean(s, channels='FL1')
-                            for s in samples]
+                            for s in list(samples.values())]
     plt.figure(figsize=(5.5, 3.5))
     plt.plot(iptg,
              samples_fluorescence,


### PR DESCRIPTION
Change `excel_ui.process_beads_table()` and `excel_ui.process_samples_table()` to output `OrderedDict` data structures keyed on IDs from corresponding Beads and Samples tables. Also update related code and documentation accordingly.

Closes https://github.com/taborlab/FlowCal/issues/232.

All unit tests pass in `Python 3.8 + Anaconda 2020.02` and `Python 2.7 + Anaconda 4.4.0`.

`>python -m FlowCal.excel_ui -v -p -H -i ./examples/experiment.xlsx` works without error in `Python 3.8 + Anaconda 2020.02` and `Python 2.7 + Anaconda 4.4.0`. Outputs (plots and Excel file) generated before and after the change appear the same in `Python 3.8 + Anaconda 2020.02`.

`>python ./examples/analyze_excel_ui.py` works without error in `Python 3.8 + Anaconda 2020.02`.