### PR TITLE
Correct numpy minimum requirement

### DIFF
--- a/doc/getting_started/install_python.rst
+++ b/doc/getting_started/install_python.rst
@@ -11,7 +11,7 @@ Alternatively, download ``FlowCal`` from `here <https://github.com/taborlab/Flow
 
 * ``packaging`` (>=16.8)
 * ``six`` (>=1.10.0)
-* ``numpy`` (>=1.8.2)
+* ``numpy`` (>=1.9.0)
 * ``scipy`` (>=0.14.0)
 * ``matplotlib`` (>=2.0.0)
 * ``palettable`` (>=2.1.1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 packaging>=16.8
 six>=1.10.0
-numpy>=1.8.2
+numpy>=1.9.0
 scipy>=0.14.0
 matplotlib>=2.0.0
 palettable>=2.1.1

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup(
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=['packaging>=16.8',
                       'six>=1.10.0',
-                      'numpy>=1.8.2',
+                      'numpy>=1.9.0',
                       'scipy>=0.14.0',
                       'matplotlib>=2.0.0',
                       'palettable>=2.1.1',


### PR DESCRIPTION
`io.FCSFile` uses `tobytes()` on a numpy array, which was not
introduced until numpy version 1.9.0. Make numpy v1.9.0 the
minimum requirement for FlowCal.