### PR TITLE
Restructure excel_ui.run() to process Excel files lacking Beads or Samples sheets.

### DIFF
--- a/FlowCal/excel_ui.py
+++ b/FlowCal/excel_ui.py
@@ -20,9 +20,9 @@ should contain the following tables:
       - **Time Channel**: Name of the time channel, as specified by the
         ``$PnN`` keyword in the associated FCS files.
 
-    - **Beads**: Describes the calibration beads samples that will be used
-      to calibrate cell samples in the **Samples** table. The following
-      information should be available for each beads sample:
+    - **Beads** (optional): Describes the calibration beads samples that will
+      be used to calibrate cell samples in the **Samples** table. The
+      following information should be available for each beads sample:
 
       - **ID**: Short string identifying the beads sample. Will be
         referenced by cell samples in the **Samples** table.
@@ -42,8 +42,9 @@ should contain the following tables:
       - **Clustering Channels**: The fluorescence channels used to identify
         the different bead subpopulations.
 
-    - **Samples**: Describes the biological samples to be processed. The
-      following information should be available for each sample:
+    - **Samples** (optional): Describes the biological samples to be
+      processed. The following information should be available for each
+      sample:
 
       - **ID**: Short string identifying the sample. Will be used as part
         of the plot's filenames and in the **Histograms** table in the
@@ -1527,17 +1528,15 @@ def run(input_path=None,
 
      1. If `input_path` is not specified, show a dialog to choose an input
         Excel file.
-     2. Extract data from the Instruments, Beads, and Samples tables.
-     3. Process all the bead samples specified in the Beads table.
-     4. Generate statistics for each bead sample.
-     5. Process all the cell samples in the Samples table.
-     6. Generate statistics for each sample.
-     7. If requested, generate a histogram table for each fluorescent
-        channel specified for each sample.
-     8. Generate a table with run time, date, FlowCal version, among
-        others.
-     9. Save statistics and (if requested) histograms in an output Excel
-        file.
+     2. Read the Instruments table from the Instruments sheet.
+     3. If a Beads sheet is specified, read the Beads table, process beads
+        samples, and calculate statistics.
+     4. If a Samples sheet is specified, read the Samples table, process
+        samples, calculate statistics, and (if requested) generate a
+        histogram table describing each fluorescence channel of each sample.
+     5. Generate a table describing the run (e.g. with run time, date,
+        FlowCal version, etc.).
+     6. Save tables and calculated statistics to an output Excel file.
 
     Parameters
     ----------
@@ -1555,7 +1554,7 @@ def run(input_path=None,
         sample, and each beads sample.
     hist_sheet : bool, optional
         Whether to generate a sheet in the output Excel file specifying
-        histogram bin information.
+        histogram bin information. Ignored if Samples sheet is not specified.
 
     """
     # If input file has not been specified, show open file dialog

--- a/FlowCal/excel_ui.py
+++ b/FlowCal/excel_ui.py
@@ -785,7 +785,9 @@ def process_samples_table(samples_table,
                     elif units.lower() == 'mef':
                         units_label = "Molecules of Equivalent Fluorophore, MEF"
                         # Check if transformation function is available
-                        if mef_transform_fxns[sample_row['Beads ID']] is None:
+                        if mef_transform_fxns is None or \
+                                mef_transform_fxns[sample_row['Beads ID']] \
+                                is None:
                             raise ExcelUIException("MEF transformation "
                                 "function not available")
 

--- a/doc/excel_ui/analysis.rst
+++ b/doc/excel_ui/analysis.rst
@@ -5,7 +5,7 @@ The analysis that FlowCal's Excel UI performs is divided roughly in two phases: 
 
 Processing of Calibration Beads
 -------------------------------
-The following steps are performed for each calibration beads sample specified in the **Beads** sheet of the :doc:`input Excel file<input_format>`:
+If a **Beads** sheet is specified, the following steps are performed for each calibration beads sample:
 
 1. :doc:`Density gating</fundamentals/density_gate>` is applied in the forward/side scatter channels. This is an automated procedure that eliminates microbead aggregates and debris.
 2. The individual microbead subpopulations are identified using automated clustering.
@@ -19,7 +19,7 @@ For an introductory discussion of flow cytometry calibration, go to the :doc:`fu
 
 Processing of Cell Samples
 --------------------------
-The following steps are performed for each cell sample specified in the **Samples** sheet of the :doc:`input Excel file<input_format>`:
+If a **Samples** sheet is specified, the following steps are performed for each sample:
 
 1. :doc:`Density gating</fundamentals/density_gate>` is applied in the forward/side scatter channels.
 2. Fluorescence data for each specified fluorescence channel is transformed to the units specified in the **Units** column of the :doc:`input Excel file<input_format>`.

--- a/doc/excel_ui/input_format.rst
+++ b/doc/excel_ui/input_format.rst
@@ -1,7 +1,7 @@
 Format of the Input Excel File
 ==============================
 
-``FlowCal``'s Excel interface requires a properly formatted Excel file that depicts the samples to be analyzed and the data processing parameters. The Excel input file must have at least three sheets, named **Instruments**, **Beads**, and **Samples**. Other sheets may be present, but ``FlowCal`` will ignore them.
+``FlowCal``'s Excel interface requires a properly formatted Excel file that depicts the samples to be analyzed and the data processing parameters. The Excel input file must have an **Instruments** sheet and typically also has **Beads** and **Samples** sheets. Other sheets may also be present, but ``FlowCal`` will ignore them.
 
 .. warning:: Sheet and column names are case-sensitive.
 

--- a/doc/excel_ui/outputs.rst
+++ b/doc/excel_ui/outputs.rst
@@ -1,12 +1,14 @@
 Outputs of the Excel UI
 =======================
 
-During processing of the calibration beads and cell samples, ``FlowCal`` creates two folders with images and an output Excel file in the same location as the :doc:`input Excel file<input_format>`. Here we describe these. In what follows, <ID> refers to the value specified in the ID column of the input Excel file.
+The ``FlowCal`` Excel UI creates analysis plots and an output Excel file. If a Beads sheet is specified in the input Excel file, a `plot_beads` folder is created containing relevant plots. Similarly, if a Samples sheet is specified, a `plot_samples` folder is created with relevant plots. Beads and Samples sheets are also populated in the output Excel file if specified in the input Excel file.
 
 .. _excel-ui-outputs-plots:
 
 Plots
 -----
+
+Note: `<ID>` refers to the unique ID of a sample as labeled in the ID column of the input Excel file.
 
 1. The folder ``plot_beads`` contains plots of the individual steps of processing of the calibration particle samples:
 


### PR DESCRIPTION
#### Testing

I created the following variants of `examples/experiment.xlsx`:

`experiment_nobeads.xlsx` (Units changed from MEF to RFI)
`experiment_nosamples.xlsx`
`experiment_nobeads_nosamples.xlsx`

and ran the Excel UI (`>python -m FlowCal.excel_ui -i experiment*.xlsx -v -p`), and the output files (XLSX file and plots) were created as expected in both `Python 3.8 + Anaconda 2020.02` and `Python 2.7 + Anaconda 5.2.0`.

Running the Excel UI with `develop` (3affd34e00060b9212cfc9093aa9695763aa8e96) threw errors related to the absence of the Excel sheets.