### PR TITLE
Fix bug where violins fail to render with old numpy.

### DIFF
--- a/FlowCal/plot.py
+++ b/FlowCal/plot.py
@@ -1805,8 +1805,10 @@ def violin(data,
     if bin_edges is None:
         if data_scale == 'logicle':
             t = _LogicleTransform(data=data, channel=channel)
-            t_min = t.inverted().transform_non_affine(data_lim[0])
-            t_max = t.inverted().transform_non_affine(data_lim[1])
+            t_min = t.inverted().transform_non_affine(x=data_lim[0],
+                                                      mask_out_of_range=False)
+            t_max = t.inverted().transform_non_affine(x=data_lim[1],
+                                                      mask_out_of_range=False)
             t_bin_edges = np.linspace(t_min, t_max, num_bins+1)
             bin_edges = t.transform_non_affine(t_bin_edges)
         elif data_scale == 'linear':
@@ -2494,8 +2496,10 @@ def violin_dose_response(data,
     if bin_edges is None:
         if yscale == 'logicle':
             t = _LogicleTransform(data=all_data, channel=channel)
-            t_ymin = t.inverted().transform_non_affine(ylim[0])
-            t_ymax = t.inverted().transform_non_affine(ylim[1])
+            t_ymin = t.inverted().transform_non_affine(x=ylim[0],
+                                                       mask_out_of_range=False)
+            t_ymax = t.inverted().transform_non_affine(x=ylim[1],
+                                                       mask_out_of_range=False)
             t_bin_edges = np.linspace(t_ymin, t_ymax, num_bins+1)
             bin_edges = t.transform_non_affine(t_bin_edges)
         elif yscale == 'linear':
@@ -2507,8 +2511,10 @@ def violin_dose_response(data,
     if min_bin_edges is None:
         if yscale == 'logicle':
             t = _LogicleTransform(data=all_data, channel=channel)
-            t_ymin = t.inverted().transform_non_affine(ylim[0])
-            t_ymax = t.inverted().transform_non_affine(ylim[1])
+            t_ymin = t.inverted().transform_non_affine(x=ylim[0],
+                                                       mask_out_of_range=False)
+            t_ymax = t.inverted().transform_non_affine(x=ylim[1],
+                                                       mask_out_of_range=False)
             t_min_bin_edges = np.linspace(t_ymin, t_ymax, num_bins+1)
             min_bin_edges = t.transform_non_affine(t_min_bin_edges)
         elif yscale == 'linear':
@@ -2520,8 +2526,10 @@ def violin_dose_response(data,
     if max_bin_edges is None:
         if yscale == 'logicle':
             t = _LogicleTransform(data=all_data, channel=channel)
-            t_ymin = t.inverted().transform_non_affine(ylim[0])
-            t_ymax = t.inverted().transform_non_affine(ylim[1])
+            t_ymin = t.inverted().transform_non_affine(x=ylim[0],
+                                                       mask_out_of_range=False)
+            t_ymax = t.inverted().transform_non_affine(x=ylim[1],
+                                                       mask_out_of_range=False)
             t_max_bin_edges = np.linspace(t_ymin, t_ymax, num_bins+1)
             max_bin_edges = t.transform_non_affine(t_max_bin_edges)
         elif yscale == 'linear':


### PR DESCRIPTION
Violin plots calculate default logicle scale bin edges using an inverse `_LogicleTransform()`, which itself uses `np.interp()`. Before numpy v1.15.0, `np.interp()` behaves differently with empty masked array inputs, which the inverse `_LogicleTransform()` may provide by default if transform values are outside its range. This fix deactivates the masking of values outside the transform range in the violin plot functions, which causes `np.interp()` to simply return the default `left` or `right` value (e.g., max or min of the scale).

All unit tests pass and `examples/analyze_no_mef.py`, `examples/analyze_mef.py`, `examples/analyze_excel_ui.py`, and `python -m FlowCal.excel_ui -v -p -i experiment.xlsx` run correctly in `Python 3.8 + Anaconda 2020.07` and `Python 2.7 + Anaconda 5.2.0`. The empty list test scripts from https://github.com/taborlab/FlowCal/pull/348 also run correctly in both environments.

Before this fix, some plots from the plot violin stress test scripts (listed in https://github.com/taborlab/FlowCal/pull/335) failed to render in `Python 2.7 + Anaconda 5.2.0`. After this fix, all plots render as expected. (All plots rendered correctly in `Python 3.8 + Anaconda 2020.07` both before and after this fix.)